### PR TITLE
Logging claims received

### DIFF
--- a/src/SFA.DAS.AssessorService.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/AccountController.cs
@@ -37,6 +37,12 @@ namespace SFA.DAS.AssessorService.Web.Controllers
         [HttpGet]
         public async Task<IActionResult> PostSignIn()
         {
+            var claims = _contextAccessor.HttpContext.User.Claims;
+            foreach (var claim in claims)
+            {
+                _logger.LogInformation($"Claim received: {claim.Type} Value: {claim.Value}");
+            }
+
             _logger.LogInformation("Start of PostSignIn");
             var loginResult = await _loginOrchestrator.Login(_contextAccessor.HttpContext);
             switch (loginResult)


### PR DESCRIPTION
So it turns out the error on the AT site is because we're not receiving an email address back from claims.  This PR is to output to logs ALL of the claims we're receiving so we can see what's being returned to us.