### PR TITLE
On 457 ensure session keys scoped to env

### DIFF
--- a/src/SFA.DAS.AssessorService.Application.Api/appsettings.Development.json
+++ b/src/SFA.DAS.AssessorService.Application.Api/appsettings.Development.json
@@ -7,7 +7,7 @@
       "Microsoft": "Information"
     }
   },
-  "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true",
+  "ConfigurationStorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=esfatempstorage;AccountKey=TPb6erJ7bRn6UasaGH3Jo1q0cOmtEEVlZAEbxGl1TYtlqhct/A0ssNex/7IUi/+9QyHwSujtx997IC8wTIwd4w==;EndpointSuffix=core.windows.net",
   "ConnectionStrings": {
     "Redis": "localhost:6379",
     "Storage": "UseDevelopmentStorage=true;"

--- a/src/SFA.DAS.AssessorService.Application.Api/appsettings.Development.json
+++ b/src/SFA.DAS.AssessorService.Application.Api/appsettings.Development.json
@@ -7,7 +7,7 @@
       "Microsoft": "Information"
     }
   },
-  "ConfigurationStorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=esfatempstorage;AccountKey=TPb6erJ7bRn6UasaGH3Jo1q0cOmtEEVlZAEbxGl1TYtlqhct/A0ssNex/7IUi/+9QyHwSujtx997IC8wTIwd4w==;EndpointSuffix=core.windows.net",
+  "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
   "ConnectionStrings": {
     "Redis": "localhost:6379",
     "Storage": "UseDevelopmentStorage=true;"

--- a/src/SFA.DAS.AssessorService.Settings/WebConfiguration.cs
+++ b/src/SFA.DAS.AssessorService.Settings/WebConfiguration.cs
@@ -20,6 +20,6 @@ namespace SFA.DAS.AssessorService.Settings
 
         [JsonRequired] public string SqlConnectionString { get; set; }
 
-        [JsonRequired] public string SessionRedisConnectionString { get; set; }
+        public string SessionRedisConnectionString { get; set; }
     }
 }

--- a/src/SFA.DAS.AssessorService.Web.UnitTests/AccountControllerTests/Given_I_have_signed_in.cs
+++ b/src/SFA.DAS.AssessorService.Web.UnitTests/AccountControllerTests/Given_I_have_signed_in.cs
@@ -10,6 +10,7 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.AssessorService.Api.Types.Models;
 using SFA.DAS.AssessorService.Web.Controllers;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.Orchestrators.Login;
 
 namespace SFA.DAS.AssessorService.Web.UnitTests.AccountControllerTests
@@ -35,7 +36,7 @@ namespace SFA.DAS.AssessorService.Web.UnitTests.AccountControllerTests
 
             _loginOrchestrator = new Mock<ILoginOrchestrator>();
 
-            _accountController = new AccountController(_contextAccessor.Object, new Mock<ILogger<AccountController>>().Object, _loginOrchestrator.Object);
+            _accountController = new AccountController(new Mock<ILogger<AccountController>>().Object, _loginOrchestrator.Object, new Mock<ISessionService>().Object);
         }
 
         [Test]

--- a/src/SFA.DAS.AssessorService.Web.UnitTests/AccountControllerTests/Given_I_request_Sign_In.cs
+++ b/src/SFA.DAS.AssessorService.Web.UnitTests/AccountControllerTests/Given_I_request_Sign_In.cs
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
 using SFA.DAS.AssessorService.Web.Controllers;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.Orchestrators.Login;
 
 namespace SFA.DAS.AssessorService.Web.UnitTests.AccountControllerTests
@@ -29,7 +30,7 @@ namespace SFA.DAS.AssessorService.Web.UnitTests.AccountControllerTests
                 .Returns("callbackUrl")
                 .Verifiable();
 
-            _accountController = new AccountController(new Mock<IHttpContextAccessor>().Object, new Mock<ILogger<AccountController>>().Object, new Mock<ILoginOrchestrator>().Object);
+            _accountController = new AccountController(new Mock<ILogger<AccountController>>().Object, new Mock<ILoginOrchestrator>().Object, new Mock<ISessionService>().Object);
 
             _accountController.Url = mockUrlHelper.Object;
         }

--- a/src/SFA.DAS.AssessorService.Web.UnitTests/SearchControllerTests/SearchControllerTestBase.cs
+++ b/src/SFA.DAS.AssessorService.Web.UnitTests/SearchControllerTests/SearchControllerTestBase.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using SFA.DAS.AssessorService.Api.Types.Models;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
 using SFA.DAS.AssessorService.Web.Controllers;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.Orchestrators.Search;
 
 namespace SFA.DAS.AssessorService.Web.UnitTests.SearchControllerTests
@@ -37,7 +38,7 @@ namespace SFA.DAS.AssessorService.Web.UnitTests.SearchControllerTests
             var orchestrator = new SearchOrchestrator(new Mock<ILogger<SearchController>>().Object, searchApiClient.Object,
                 contextAccessor.Object);
 
-            SearchController = new SearchController(orchestrator, contextAccessor.Object);
+            SearchController = new SearchController(orchestrator, new Mock<ISessionService>().Object);
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/AccountController.cs
@@ -3,10 +3,10 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.WsFederation;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.AssessorService.Api.Types.Models;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.Orchestrators.Login;
 
 namespace SFA.DAS.AssessorService.Web.Controllers
@@ -14,15 +14,15 @@ namespace SFA.DAS.AssessorService.Web.Controllers
     [Route("[controller]/[action]")]
     public class AccountController : Controller
     {
-        private readonly IHttpContextAccessor _contextAccessor;
         private readonly ILogger<AccountController> _logger;
         private readonly ILoginOrchestrator _loginOrchestrator;
+        private readonly ISessionService _sessionService;
 
-        public AccountController(IHttpContextAccessor contextAccessor, ILogger<AccountController> logger, ILoginOrchestrator loginOrchestrator)
+        public AccountController(ILogger<AccountController> logger, ILoginOrchestrator loginOrchestrator, ISessionService sessionService)
         {
-            _contextAccessor = contextAccessor;
             _logger = logger;
             _loginOrchestrator = loginOrchestrator;
+            _sessionService = sessionService;
         }
 
         [HttpGet]
@@ -42,7 +42,7 @@ namespace SFA.DAS.AssessorService.Web.Controllers
             switch (loginResult.Result)
             {
                 case LoginResult.Valid:
-                    _contextAccessor.HttpContext.Session.SetString("OrganisationName", loginResult.OrganisationName);
+                    _sessionService.Set("OrganisationName", loginResult.OrganisationName);
                     return RedirectToAction("Index", "Search");
                 case LoginResult.NotRegistered:
                     return RedirectToAction("NotRegistered", "Home");

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateAddressController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateAddressController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 
 namespace SFA.DAS.AssessorService.Web.Controllers
@@ -13,7 +14,7 @@ namespace SFA.DAS.AssessorService.Web.Controllers
     public class CertificateAddressController : CertificateBaseController
     {
         public CertificateAddressController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor,
-            ICertificateApiClient certificateApiClient) : base(logger, contextAccessor, certificateApiClient)
+            ICertificateApiClient certificateApiClient, ISessionService sessionService) : base(logger, contextAccessor, certificateApiClient, sessionService)
         {}
 
         [HttpGet]

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateBaseController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateBaseController.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using SFA.DAS.AssessorService.Api.Types.Models.Certificates;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
 using SFA.DAS.AssessorService.Domain.JsonData;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 
 namespace SFA.DAS.AssessorService.Web.Controllers
@@ -17,12 +18,14 @@ namespace SFA.DAS.AssessorService.Web.Controllers
         protected readonly ILogger<CertificateController> Logger;
         private readonly IHttpContextAccessor _contextAccessor;
         private readonly ICertificateApiClient _certificateApiClient;
+        private readonly ISessionService _sessionService;
 
-        public CertificateBaseController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor, ICertificateApiClient certificateApiClient)
+        public CertificateBaseController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor, ICertificateApiClient certificateApiClient, ISessionService sessionService)
         {
             Logger = logger;
             _contextAccessor = contextAccessor;
             _certificateApiClient = certificateApiClient;
+            _sessionService = sessionService;
         }
         protected async Task<IActionResult> LoadViewModel<T>(string view) where T : ICertificateViewModel, new()
         {
@@ -34,12 +37,12 @@ namespace SFA.DAS.AssessorService.Web.Controllers
             if (query.ContainsKey("redirecttocheck") && bool.Parse(query["redirecttocheck"]))
             {
                 Logger.LogInformation($"RedirectToCheck for {typeof(T).Name} is true");
-                _contextAccessor.HttpContext.Session.SetString("redirecttocheck", "true");
+                _sessionService.Set("redirecttocheck", "true");
             }
             else
-                _contextAccessor.HttpContext.Session.Remove("redirecttocheck");
-
-            var sessionString = _contextAccessor.HttpContext.Session.GetString("CertificateSession");
+                _sessionService.Remove("redirecttocheck");
+                
+            var sessionString = _sessionService.Get("CertificateSession");
             if (sessionString == null)
             {
                 Logger.LogInformation($"Session for {typeof(T).Name} requested by {username} has been lost. Redirecting to Search Index");

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateCheckController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateCheckController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 
 namespace SFA.DAS.AssessorService.Web.Controllers
@@ -13,7 +14,7 @@ namespace SFA.DAS.AssessorService.Web.Controllers
     public class CertificateCheckController : CertificateBaseController
     {
         public CertificateCheckController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor,
-            ICertificateApiClient certificateApiClient) : base(logger, contextAccessor, certificateApiClient)
+            ICertificateApiClient certificateApiClient, ISessionService sessionService) : base(logger, contextAccessor, certificateApiClient, sessionService)
         {}
 
         [HttpGet]

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateConfirmationController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateConfirmationController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 
 namespace SFA.DAS.AssessorService.Web.Controllers
@@ -12,12 +13,12 @@ namespace SFA.DAS.AssessorService.Web.Controllers
     [Route("certificate/confirmation")]
     public class CertificateConfirmationController : CertificateBaseController
     {
-        private readonly IHttpContextAccessor _contextAccessor;
+        private readonly ISessionService _sessionService;
 
         public CertificateConfirmationController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor,
-            ICertificateApiClient certificateApiClient) : base(logger, contextAccessor, certificateApiClient)
+            ICertificateApiClient certificateApiClient, ISessionService sessionService) : base(logger, contextAccessor, certificateApiClient, sessionService)
         {
-            _contextAccessor = contextAccessor;
+            _sessionService = sessionService;
         }
 
         [HttpGet]
@@ -25,7 +26,7 @@ namespace SFA.DAS.AssessorService.Web.Controllers
         {
             var actionResult = await LoadViewModel<CertificateConfirmationViewModel>("~/Views/Certificate/Confirmation.cshtml");
 
-            _contextAccessor.HttpContext.Session.Remove("CertificateSession");
+            _sessionService.Remove("CertificateSession");
 
             return actionResult;
         }

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateDateController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateDateController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.Validators;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 
@@ -18,7 +19,7 @@ namespace SFA.DAS.AssessorService.Web.Controllers
         private readonly CertificateDateViewModelValidator _validator;
 
         public CertificateDateController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor,
-            ICertificateApiClient certificateApiClient, CertificateDateViewModelValidator validator) : base(logger, contextAccessor, certificateApiClient)
+            ICertificateApiClient certificateApiClient, CertificateDateViewModelValidator validator, ISessionService sessionService) : base(logger, contextAccessor, certificateApiClient, sessionService)
         {
             _validator = validator;
         }

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateDeclarationController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateDeclarationController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 
 namespace SFA.DAS.AssessorService.Web.Controllers
@@ -13,7 +14,7 @@ namespace SFA.DAS.AssessorService.Web.Controllers
     public class CertificateDeclarationController : CertificateBaseController
     {
         public CertificateDeclarationController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor,
-            ICertificateApiClient certificateApiClient) : base(logger, contextAccessor, certificateApiClient)
+            ICertificateApiClient certificateApiClient, ISessionService sessionService) : base(logger, contextAccessor, certificateApiClient, sessionService)
         {}
 
         [HttpGet]

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateGradeController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateGradeController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 
 namespace SFA.DAS.AssessorService.Web.Controllers
@@ -12,8 +13,8 @@ namespace SFA.DAS.AssessorService.Web.Controllers
     [Route("certificate/grade")]
     public class CertificateGradeController : CertificateBaseController
     {
-        public CertificateGradeController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor, ICertificateApiClient certificateApiClient)
-            : base(logger, contextAccessor, certificateApiClient)
+        public CertificateGradeController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor, ICertificateApiClient certificateApiClient, ISessionService sessionService)
+            : base(logger, contextAccessor, certificateApiClient, sessionService)
         {}
 
         [HttpGet]

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateOptionController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateOptionController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Web.Infrastructure;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 
 namespace SFA.DAS.AssessorService.Web.Controllers
@@ -12,8 +13,8 @@ namespace SFA.DAS.AssessorService.Web.Controllers
     [Route("certificate/option")]
     public class CertificateOptionController : CertificateBaseController
     {
-        public CertificateOptionController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor, ICertificateApiClient certificateApiClient)
-            :base(logger, contextAccessor, certificateApiClient)
+        public CertificateOptionController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor, ICertificateApiClient certificateApiClient, ISessionService sessionService)
+            :base(logger, contextAccessor, certificateApiClient, sessionService)
         {}
 
         [HttpGet]

--- a/src/SFA.DAS.AssessorService.Web/Infrastructure/CheckSessionFilter.cs
+++ b/src/SFA.DAS.AssessorService.Web/Infrastructure/CheckSessionFilter.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
@@ -9,24 +8,25 @@ namespace SFA.DAS.AssessorService.Web.Infrastructure
     public class CheckSessionFilter : IActionFilter
     {
         private ILogger<CheckSessionAttribute> _logger;
+        private readonly ISessionService _sessionService;
 
-        public CheckSessionFilter(ILogger<CheckSessionAttribute> logger)
+        public CheckSessionFilter(ILogger<CheckSessionAttribute> logger, ISessionService sessionService)
         {
             _logger = logger;
+            _sessionService = sessionService;
         }
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            var meterAttribute = context.Controller.GetType().GetTypeInfo()
+            var checkSessionAttribute = context.Controller.GetType().GetTypeInfo()
                 .GetCustomAttribute<CheckSessionAttribute>();
 
-            if (meterAttribute == null)
+            if (checkSessionAttribute == null)
             {
                 return;
             }
 
-            var session = context.HttpContext.Session;
-            if (session.GetString("OrganisationName") == null)
+            if (_sessionService.Get("OrganisationName") == null)
             {
                 context.Result = new RedirectToActionResult("SignIn", "Account", null);
                 _logger.LogInformation("Session lost, redirecting to Sign In");

--- a/src/SFA.DAS.AssessorService.Web/Infrastructure/ISessionService.cs
+++ b/src/SFA.DAS.AssessorService.Web/Infrastructure/ISessionService.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using SFA.DAS.AssessorService.Web.Controllers;
+
+namespace SFA.DAS.AssessorService.Web.Infrastructure
+{
+    public interface ISessionService
+    {
+        void Set(string key, object value);
+        void Remove(string key);
+        string Get(string key);
+    }
+
+    class SessionService : ISessionService
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly string _environment;
+
+        public SessionService(IHttpContextAccessor httpContextAccessor, string environment)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _environment = environment;
+        }
+        
+        public void Set(string key, object value)
+        {
+            _httpContextAccessor.HttpContext.Session.SetString(_environment + "_" + key,
+                JsonConvert.SerializeObject(value));
+        }
+
+        public void Remove(string key)
+        {
+            _httpContextAccessor.HttpContext.Session.Remove(_environment + "_" + key);
+        }
+
+        public string Get(string key)
+        {
+            return _httpContextAccessor.HttpContext.Session.GetString(_environment + "_" + key);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Web/Infrastructure/ISessionService.cs
+++ b/src/SFA.DAS.AssessorService.Web/Infrastructure/ISessionService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using SFA.DAS.AssessorService.Web.Controllers;
 
@@ -7,8 +8,10 @@ namespace SFA.DAS.AssessorService.Web.Infrastructure
     public interface ISessionService
     {
         void Set(string key, object value);
+        void Set(string key, string stringValue);
         void Remove(string key);
         string Get(string key);
+        T Get<T>(string key);
     }
 
     class SessionService : ISessionService
@@ -28,6 +31,12 @@ namespace SFA.DAS.AssessorService.Web.Infrastructure
                 JsonConvert.SerializeObject(value));
         }
 
+        public void Set(string key, string stringValue)
+        {
+            _httpContextAccessor.HttpContext.Session.SetString(_environment + "_" + key,
+                stringValue);
+        }
+
         public void Remove(string key)
         {
             _httpContextAccessor.HttpContext.Session.Remove(_environment + "_" + key);
@@ -36,6 +45,21 @@ namespace SFA.DAS.AssessorService.Web.Infrastructure
         public string Get(string key)
         {
             return _httpContextAccessor.HttpContext.Session.GetString(_environment + "_" + key);
+        }
+
+        public T Get<T>(string key)
+        {
+            var session = _httpContextAccessor.HttpContext.Session;
+            key = _environment + "_" + key;
+
+            if (session.Keys.All(k => k != key))
+            {
+                return default(T);
+            }
+
+            var value = session.GetString(key);
+
+            return string.IsNullOrWhiteSpace(value) ? default(T): JsonConvert.DeserializeObject<T>(value);
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Web/SFA.DAS.AssessorService.Web.csproj
+++ b/src/SFA.DAS.AssessorService.Web/SFA.DAS.AssessorService.Web.csproj
@@ -1,16 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
-
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Services\**" />
     <Content Remove="Services\**" />
     <EmbeddedResource Remove="Services\**" />
     <None Remove="Services\**" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.2.2" />
     <PackageReference Include="BuildBundlerMinifier" Version="2.6.362" />
@@ -22,19 +19,16 @@
     <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="1.4.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.6.362" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.AssessorService.Application.Api.Client\SFA.DAS.AssessorService.Application.Api.Client.csproj" />
     <ProjectReference Include="..\SFA.DAS.AssessorService.Settings\SFA.DAS.AssessorService.Settings.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Resources\Views\Certificate\Declaration.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -42,7 +36,6 @@
       <DependentUpon>Declaration.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="Resources\Validators\CertificateAddressViewModelValidator.en.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -91,5 +84,4 @@
       <Generator>ResXFileCodeGenerator</Generator>
     </EmbeddedResource>
   </ItemGroup>
-
 </Project>

--- a/src/SFA.DAS.AssessorService.Web/Startup.cs
+++ b/src/SFA.DAS.AssessorService.Web/Startup.cs
@@ -93,7 +93,8 @@ namespace SFA.DAS.AssessorService.Web
                 config.For<ISearchApiClient>().Use<SearchApiClient>().Ctor<string>().Is(Configuration.ClientApiAuthentication.ApiBaseAddress);
                 config.For<ICertificateApiClient>().Use<CertificateApiClient>().Ctor<string>().Is(Configuration.ClientApiAuthentication.ApiBaseAddress);
                 config.For<ILoginApiClient>().Use<LoginApiClient>().Ctor<string>().Is(Configuration.ClientApiAuthentication.ApiBaseAddress);
-
+                config.For<ISessionService>().Use<SessionService>().Ctor<string>().Is(_env.EnvironmentName);
+                
                 config.Populate(services);
             });
 

--- a/src/SFA.DAS.AssessorService.Web/Startup.cs
+++ b/src/SFA.DAS.AssessorService.Web/Startup.cs
@@ -61,14 +61,20 @@ namespace SFA.DAS.AssessorService.Web
             }
             else
             {
-                services.AddDistributedRedisCache(options =>
+                if (!string.IsNullOrEmpty(Configuration.SessionRedisConnectionString))
                 {
-                    options.Configuration = Configuration.SessionRedisConnectionString;
-                });
+                    services.AddDistributedRedisCache(options =>
+                    {
+                        options.Configuration = Configuration.SessionRedisConnectionString;
+                    });
+                }
+                else
+                {
+                    services.AddDistributedMemoryCache();
+                }
             }
 
             services.AddSession(opt => { opt.IdleTimeout = TimeSpan.FromHours(1); });
-
 
             return ConfigureIOC(services);
         }
@@ -94,7 +100,7 @@ namespace SFA.DAS.AssessorService.Web
                 config.For<ICertificateApiClient>().Use<CertificateApiClient>().Ctor<string>().Is(Configuration.ClientApiAuthentication.ApiBaseAddress);
                 config.For<ILoginApiClient>().Use<LoginApiClient>().Ctor<string>().Is(Configuration.ClientApiAuthentication.ApiBaseAddress);
                 config.For<ISessionService>().Use<SessionService>().Ctor<string>().Is(_env.EnvironmentName);
-                
+
                 config.Populate(services);
             });
 

--- a/src/SFA.DAS.AssessorService.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.AssessorService.Web/Views/Shared/_Layout.cshtml
@@ -1,4 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Http
+@using SFA.DAS.AssessorService.Web.Infrastructure
+@inject ISessionService SessionService
 <!DOCTYPE html>
 <html>
 
@@ -117,7 +119,7 @@
             <div id="header-user--nav" class="grid-row">
                 <div class="column-two-thirds">
                     <h2 class="heading-small">
-                        @Context.Session.GetString("OrganisationName")
+                        @SessionService.Get("OrganisationName")
                         <span class="heading-secondary">
                             <span class="visuallyhidden">Logged in as </span>@User.Identity.Name
                         </span>

--- a/src/SFA.DAS.AssessorService.Web/appsettings.Development.json
+++ b/src/SFA.DAS.AssessorService.Web/appsettings.Development.json
@@ -7,7 +7,7 @@
       "Microsoft": "Information"
     }
   },
-  "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true",
+  "ConfigurationStorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=esfatempstorage;AccountKey=TPb6erJ7bRn6UasaGH3Jo1q0cOmtEEVlZAEbxGl1TYtlqhct/A0ssNex/7IUi/+9QyHwSujtx997IC8wTIwd4w==;EndpointSuffix=core.windows.net",
   "ConnectionStrings": {
     "Redis": "localhost:6379"
   },

--- a/src/SFA.DAS.AssessorService.Web/appsettings.Development.json
+++ b/src/SFA.DAS.AssessorService.Web/appsettings.Development.json
@@ -7,7 +7,7 @@
       "Microsoft": "Information"
     }
   },
-  "ConfigurationStorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=esfatempstorage;AccountKey=TPb6erJ7bRn6UasaGH3Jo1q0cOmtEEVlZAEbxGl1TYtlqhct/A0ssNex/7IUi/+9QyHwSujtx997IC8wTIwd4w==;EndpointSuffix=core.windows.net",
+  "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
   "ConnectionStrings": {
     "Redis": "localhost:6379"
   },

--- a/src/SFA.DAS.AssessorService.Web/appsettings.json
+++ b/src/SFA.DAS.AssessorService.Web/appsettings.json
@@ -12,7 +12,7 @@
       }
     }
   },
-  "ConfigurationStorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=esfatempstorage;AccountKey=TPb6erJ7bRn6UasaGH3Jo1q0cOmtEEVlZAEbxGl1TYtlqhct/A0ssNex/7IUi/+9QyHwSujtx997IC8wTIwd4w==;EndpointSuffix=core.windows.net",
+  "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
   "ConnectionStrings": {
     "Redis": ""
   },

--- a/src/SFA.DAS.AssessorService.Web/appsettings.json
+++ b/src/SFA.DAS.AssessorService.Web/appsettings.json
@@ -12,7 +12,7 @@
       }
     }
   },
-  "ConfigurationStorageConnectionString": "",
+  "ConfigurationStorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=esfatempstorage;AccountKey=TPb6erJ7bRn6UasaGH3Jo1q0cOmtEEVlZAEbxGl1TYtlqhct/A0ssNex/7IUi/+9QyHwSujtx997IC8wTIwd4w==;EndpointSuffix=core.windows.net",
   "ConnectionStrings": {
     "Redis": ""
   },


### PR DESCRIPTION
New Redis Session connection string setting is no longer Required so will not crash while setting not present.
All session is now accessed through SessionService that prepends the environment name onto session keys as the Redis instance is shared across environments.