### PR TITLE
Change to logic of learner search

### DIFF
--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_assessmentorgs_api_returns_non_int_stdcode.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_assessmentorgs_api_returns_non_int_stdcode.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.AssessorService.Api.Types.Models;
 using SFA.DAS.AssessorService.Application.Interfaces;
+using SFA.DAS.AssessorService.Domain.Entities;
 using SFA.DAS.AssessorService.ExternalApis.AssessmentOrgs;
 using SFA.DAS.AssessorService.ExternalApis.AssessmentOrgs.Types;
 
@@ -16,11 +17,12 @@ namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
         [SetUp]
         public void Arrange()
         {
+            
             Setup();
         }
         
         [Test]
-        public void Then_only_the_int_values_are_sent_through_to_search()
+        public void Then_an_exception_is_not_thrown()
         {
             AssessmentOrgsApiClient.Setup(c => c.FindAllStandardsByOrganisationIdAsync("EPA0050"))
                 .ReturnsAsync(new List<StandardOrganisationSummary>
@@ -29,11 +31,10 @@ namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
                     new StandardOrganisationSummary {StandardCode = "13a"},
                     new StandardOrganisationSummary {StandardCode = "14"}
                 });
-            
-            SearchHandler.Handle(new SearchQuery(){Surname = "smith", UkPrn = 99999, Uln = 12345, Username = "dave"}, new CancellationToken()).Wait();
 
-            IlrRepository.Verify(r =>
-                r.Search(It.Is<SearchRequest>(sr => sr.FamilyName == "smith" && sr.StandardIds.Count == 2 && sr.StandardIds[0] == 12 && sr.StandardIds[1] == 14)));
+            SearchHandler
+                .Handle(new SearchQuery() {Surname = "smith", UkPrn = 99999, Uln = 12345, Username = "dave"},
+                    new CancellationToken()).Wait();
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_certificate_already_submitted_for_learner.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_certificate_already_submitted_for_learner.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
                     }
                 });
 
-            IlrRepository.Setup(r => r.Search(It.IsAny<SearchRequest>()))
+            IlrRepository.Setup(r => r.SearchForLearner(It.IsAny<SearchRequest>()))
                 .ReturnsAsync(new List<Ilr> {new Ilr() {StdCode = 12}});
         }
 

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_certificate_does_not_exist_for_learner.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_certificate_does_not_exist_for_learner.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
             CertificateRepository.Setup(r => r.GetCompletedCertificatesFor(1111111111))
                 .ReturnsAsync(new List<Certificate>());
 
-            IlrRepository.Setup(r => r.Search(It.IsAny<SearchRequest>()))
+            IlrRepository.Setup(r => r.SearchForLearner(It.IsAny<SearchRequest>()))
                 .ReturnsAsync(new List<Ilr> {new Ilr() {StdCode = 12}});
         }
 

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_learner_has_two_standards_with_one_certificate.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_learner_has_two_standards_with_one_certificate.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
                             JsonConvert.SerializeObject(new CertificateData {})}
                 });
 
-            IlrRepository.Setup(r => r.Search(It.IsAny<SearchRequest>()))
+            IlrRepository.Setup(r => r.SearchForLearner(It.IsAny<SearchRequest>()))
                 .ReturnsAsync(new List<Ilr> {new Ilr() {StdCode = 12}, new Ilr() {StdCode = 13}});
         }
 

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_returned_learners_do_not_match_users_epaorgid.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_returned_learners_do_not_match_users_epaorgid.cs
@@ -1,0 +1,103 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models;
+using SFA.DAS.AssessorService.Application.Handlers.Search;
+using SFA.DAS.AssessorService.Application.Interfaces;
+using SFA.DAS.AssessorService.Domain.Entities;
+using SFA.DAS.AssessorService.ExternalApis.AssessmentOrgs;
+using SFA.DAS.AssessorService.ExternalApis.AssessmentOrgs.Types;
+using Organisation = SFA.DAS.AssessorService.Domain.Entities.Organisation;
+
+namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
+{
+    [TestFixture]
+    public class When_returned_learners_do_not_match_users_epaorgid
+    {
+        [Test]
+        public void Then_non_matching_are_not_returned_if_not_valid_for_epao()
+        {
+            Mapper.Reset();
+            Mapper.Initialize(m => m.CreateMap<Ilr, SearchResult>());
+            
+            
+            var ilrRepository = new Mock<IIlrRepository>();
+
+            ilrRepository.Setup(r => r.SearchForLearner(It.IsAny<SearchRequest>()))
+                .ReturnsAsync(new List<Ilr>
+                {
+                    new Ilr{ EpaOrgId = "EPA0001", StdCode = 1},
+                    new Ilr{ EpaOrgId = "EPA0002", StdCode = 2},
+                    new Ilr{ EpaOrgId = "EPA0001", StdCode = 3}
+                });
+
+            var assessmentOrgsApiClient = new Mock<IAssessmentOrgsApiClient>();
+            assessmentOrgsApiClient.Setup(c => c.FindAllStandardsByOrganisationIdAsync("EPA0001"))
+                .ReturnsAsync(new List<StandardOrganisationSummary>(){new StandardOrganisationSummary(){StandardCode = "5"}});
+            assessmentOrgsApiClient.Setup(c => c.GetStandard(It.IsAny<int>()))
+                .ReturnsAsync(new Standard() {Title = "Standard Title", Level = 2});
+            
+            
+            var organisationRepository = new Mock<IOrganisationQueryRepository>();
+            organisationRepository.Setup(r => r.GetByUkPrn(12345)).ReturnsAsync(new Organisation() { EndPointAssessorOrganisationId = "EPA0001"});
+
+            var certificateRepository = new Mock<ICertificateRepository>();
+            certificateRepository.Setup(r => r.GetCompletedCertificatesFor(1111111111))
+                .ReturnsAsync(new List<Certificate>());
+            
+            
+            var handler = new SearchHandler(assessmentOrgsApiClient.Object,
+                organisationRepository.Object, ilrRepository.Object,
+                certificateRepository.Object, new Mock<ILogger<SearchHandler>>().Object);
+
+            var result = handler.Handle(new SearchQuery{ Surname = "James", Uln = 1111111111, UkPrn = 12345, Username = "user@name"}, new CancellationToken()).Result;
+
+            result.Count.Should().Be(2);
+        }
+        
+        [Test]
+        public void Then_non_matching_are_returned_if_valid_for_epao()
+        {
+            Mapper.Reset();
+            Mapper.Initialize(m => m.CreateMap<Ilr, SearchResult>());
+            
+            
+            var ilrRepository = new Mock<IIlrRepository>();
+
+            ilrRepository.Setup(r => r.SearchForLearner(It.IsAny<SearchRequest>()))
+                .ReturnsAsync(new List<Ilr>
+                {
+                    new Ilr{ EpaOrgId = "EPA0001", StdCode = 1},
+                    new Ilr{ EpaOrgId = "EPA0002", StdCode = 2},
+                    new Ilr{ EpaOrgId = "EPA0001", StdCode = 3}
+                });
+
+            var assessmentOrgsApiClient = new Mock<IAssessmentOrgsApiClient>();
+            assessmentOrgsApiClient.Setup(c => c.FindAllStandardsByOrganisationIdAsync("EPA0001"))
+                .ReturnsAsync(new List<StandardOrganisationSummary>(){new StandardOrganisationSummary(){StandardCode = "2"}});
+            assessmentOrgsApiClient.Setup(c => c.GetStandard(It.IsAny<int>()))
+                .ReturnsAsync(new Standard() {Title = "Standard Title", Level = 2});
+            
+            
+            var organisationRepository = new Mock<IOrganisationQueryRepository>();
+            organisationRepository.Setup(r => r.GetByUkPrn(12345)).ReturnsAsync(new Organisation() { EndPointAssessorOrganisationId = "EPA0001"});
+
+            var certificateRepository = new Mock<ICertificateRepository>();
+            certificateRepository.Setup(r => r.GetCompletedCertificatesFor(1111111111))
+                .ReturnsAsync(new List<Certificate>());
+            
+            
+            var handler = new SearchHandler(assessmentOrgsApiClient.Object,
+                organisationRepository.Object, ilrRepository.Object,
+                certificateRepository.Object, new Mock<ILogger<SearchHandler>>().Object);
+
+            var result = handler.Handle(new SearchQuery{ Surname = "James", Uln = 1111111111, UkPrn = 12345, Username = "user@name"}, new CancellationToken()).Result;
+
+            result.Count.Should().Be(3);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_returned_learners_match_users_epaorgid.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_returned_learners_match_users_epaorgid.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models;
+using SFA.DAS.AssessorService.Application.Handlers.Search;
+using SFA.DAS.AssessorService.Application.Interfaces;
+using SFA.DAS.AssessorService.Domain.Entities;
+using SFA.DAS.AssessorService.ExternalApis.AssessmentOrgs;
+using SFA.DAS.AssessorService.ExternalApis.AssessmentOrgs.Types;
+using Organisation = SFA.DAS.AssessorService.Domain.Entities.Organisation;
+
+namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
+{
+    [TestFixture]
+    public class When_returned_learners_match_users_epaorgid
+    {
+        [Test]
+        public void Then_those_learners_are_returned()
+        {
+            Mapper.Reset();
+            Mapper.Initialize(m => m.CreateMap<Ilr, SearchResult>());
+            
+            
+            var ilrRepository = new Mock<IIlrRepository>();
+
+            ilrRepository.Setup(r => r.SearchForLearner(It.IsAny<SearchRequest>()))
+                .ReturnsAsync(new List<Ilr>
+                {
+                    new Ilr{ EpaOrgId = "EPA0001", StdCode = 1},
+                    new Ilr{ EpaOrgId = "EPA0001", StdCode = 2},
+                    new Ilr{ EpaOrgId = "EPA0001", StdCode = 3}
+                });
+
+            var assessmentOrgsApiClient = new Mock<IAssessmentOrgsApiClient>();
+            assessmentOrgsApiClient.Setup(c => c.FindAllStandardsByOrganisationIdAsync("EPA0001"))
+                .ReturnsAsync(new List<StandardOrganisationSummary>(){new StandardOrganisationSummary(){StandardCode = "5"}});
+            assessmentOrgsApiClient.Setup(c => c.GetStandard(It.IsAny<int>()))
+                .ReturnsAsync(new Standard() {Title = "Standard Title", Level = 2});
+            
+            
+            var organisationRepository = new Mock<IOrganisationQueryRepository>();
+            organisationRepository.Setup(r => r.GetByUkPrn(12345)).ReturnsAsync(new Organisation() { EndPointAssessorOrganisationId = "EPA0001"});
+
+            var certificateRepository = new Mock<ICertificateRepository>();
+            certificateRepository.Setup(r => r.GetCompletedCertificatesFor(1111111111))
+                .ReturnsAsync(new List<Certificate>());
+            
+            
+            var handler = new SearchHandler(assessmentOrgsApiClient.Object,
+                organisationRepository.Object, ilrRepository.Object,
+                certificateRepository.Object, new Mock<ILogger<SearchHandler>>().Object);
+
+            var result = handler.Handle(new SearchQuery{ Surname = "James", Uln = 1111111111, UkPrn = 12345, Username = "user@name"}, new CancellationToken()).Result;
+
+            result.Count.Should().Be(3);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_search_contains_any_type_of_special_character.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_search_contains_any_type_of_special_character.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
         {
             SearchHandler.Handle(new SearchQuery(){Surname = surname, UkPrn = 12345, Uln = 12345, Username = "dave"}, new CancellationToken()).Wait();
             
-            IlrRepository.Verify(r => r.SearchLike(It.Is<SearchRequest>(sr => sr.FamilyName == likedSurname)));
+            IlrRepository.Verify(r => r.SearchForLearnerLike(It.Is<SearchRequest>(sr => sr.FamilyName == likedSurname)));
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_standard_exists_for_learner.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Search/When_standard_exists_for_learner.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Search
             CertificateRepository.Setup(r => r.GetCompletedCertificatesFor(1111111111))
                 .ReturnsAsync(new List<Certificate>());
 
-            IlrRepository.Setup(r => r.Search(It.IsAny<SearchRequest>()))
+            IlrRepository.Setup(r => r.SearchForLearner(It.IsAny<SearchRequest>()))
                 .ReturnsAsync(new List<Ilr> {new Ilr() {StdCode = 12}});
         }
 

--- a/src/SFA.DAS.AssessorService.Application/Handlers/Search/SearchHandler.cs
+++ b/src/SFA.DAS.AssessorService.Application/Handlers/Search/SearchHandler.cs
@@ -69,22 +69,25 @@ namespace SFA.DAS.AssessorService.Application.Handlers.Search
                     likedSurname = likedSurname.Replace(specialCharacter, '_');
                 }
                 
-                ilrResults = await _ilrRepository.SearchLike(new SearchRequest
+                ilrResults = await _ilrRepository.SearchForLearnerLike(new SearchRequest
                 {
                     FamilyName = likedSurname,
-                    Uln = request.Uln,
-                    StandardIds = intStandards
+                    Uln = request.Uln
                 });
             }
             else
             {
-                ilrResults = await _ilrRepository.Search(new SearchRequest
+                ilrResults = await _ilrRepository.SearchForLearner(new SearchRequest
                 {
                     FamilyName = request.Surname,
-                    Uln = request.Uln,
-                    StandardIds = intStandards
+                    Uln = request.Uln
                 });
             }
+
+            ilrResults = ilrResults.Where(r =>
+                r.EpaOrgId == thisEpao.EndPointAssessorOrganisationId ||
+                (r.EpaOrgId != thisEpao.EndPointAssessorOrganisationId && intStandards.Contains(r.StdCode))).ToList();
+            
 
             _logger.LogInformation(ilrResults.Any() ? LoggingConstants.SearchSuccess : LoggingConstants.SearchFailure);
 

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/IIlrRepository.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/IIlrRepository.cs
@@ -6,8 +6,8 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
 {
     public interface IIlrRepository
     {
-        Task<IEnumerable<Ilr>> Search(SearchRequest searchRequest);
-        Task<IEnumerable<Ilr>> SearchLike(SearchRequest searchRequest);
+        Task<IEnumerable<Ilr>> SearchForLearner(SearchRequest searchRequest);
+        Task<IEnumerable<Ilr>> SearchForLearnerLike(SearchRequest searchRequest);
         Task<Ilr> Get(long uln, int standardCode);
     }
 }

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/SearchRequest.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/SearchRequest.cs
@@ -6,6 +6,5 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
     {
         public long Uln { get; set; }
         public string FamilyName { get; set; }
-        public List<int> StandardIds { get; set; }
     }
 }

--- a/src/SFA.DAS.AssessorService.Data/IlrRepository.cs
+++ b/src/SFA.DAS.AssessorService.Data/IlrRepository.cs
@@ -17,27 +17,23 @@ namespace SFA.DAS.AssessorService.Data
             _context = context;
         }
 
-        public async Task<IEnumerable<Ilr>> Search(SearchRequest searchRequest)
+        public async Task<IEnumerable<Ilr>> SearchForLearner(SearchRequest searchRequest)
         {
             var learnerRecords = await _context.Ilrs.Where(r =>
                 string.Equals(r.FamilyName.Trim(), searchRequest.FamilyName.Trim(), StringComparison.CurrentCultureIgnoreCase)
                 && r.Uln == searchRequest.Uln).ToListAsync();
-                
-            learnerRecords = learnerRecords.Where(r => searchRequest.StandardIds.Contains(r.StdCode)).ToList();
-
+               
             var response = learnerRecords;
 
             return response;
         }
 
-        public async Task<IEnumerable<Ilr>> SearchLike(SearchRequest searchRequest)
+        public async Task<IEnumerable<Ilr>> SearchForLearnerLike(SearchRequest searchRequest)
         {
             var learnerRecords = await _context.Ilrs.Where(r => 
                 EF.Functions.Like(r.FamilyName, searchRequest.FamilyName)
                 && r.Uln == searchRequest.Uln).ToListAsync();
 
-            learnerRecords = learnerRecords.Where(r => searchRequest.StandardIds.Contains(r.StdCode)).ToList();
-            
             var response = learnerRecords;
 
             return response;


### PR DESCRIPTION
Learner search now only queries db for lastname & uln.  Following that only checks the user's epoa's allowed standards if the ilr epaoid is different to their own.