### PR TITLE
On 553 may18 cert import changes

### DIFF
--- a/LoadCertificateData.sql
+++ b/LoadCertificateData.sql
@@ -23,6 +23,11 @@
 --(1668 row(s) affected)
 --(1170 row(s) affected)
 
+
+-- Update existing Certificate Records with FullName and a placeholder for ProviderName
+UPDATE Certificates SET CertificateData = JSON_MODIFY(JSON_MODIFY(CertificateData, '$.ProviderName', ''), '$.FullName', JSON_VALUE(CertificateData, '$.LearnerGivenNames') + ' ' + JSON_VALUE(CertificateData, '$.LearnerFamilyName'))
+
+
 -- Create a database master key if one does not already exist, using your own password. This key is used to encrypt the credential secret in next step.
 CREATE MASTER KEY ENCRYPTION BY PASSWORD = 'Baldy N3rd Face';
 

--- a/LoadCertificateData.sql
+++ b/LoadCertificateData.sql
@@ -32,7 +32,7 @@ CREATE MASTER KEY ENCRYPTION BY PASSWORD = 'Baldy N3rd Face';
 ---- Create a database scoped credential with Azure storage account key as the secret.
 CREATE DATABASE SCOPED CREDENTIAL BlobCredential 
 WITH IDENTITY = 'SHARED ACCESS SIGNATURE', 
-SECRET = 'sv=2017-07-29&ss=bfqt&srt=sco&sp=rwdlacup&se=2018-05-24T15:18:31Z&st=2018-05-24T07:18:31Z&spr=https&sig=tMpYxCReRrwdLxiagOWPiRxiYgn3oU7yTgGTodyGH8Y%3D';
+SECRET = '';
 
 ---- Create an external data source with CREDENTIAL option.
 CREATE EXTERNAL DATA SOURCE BlobStorage WITH (

--- a/LoadCertificateData.sql
+++ b/LoadCertificateData.sql
@@ -28,7 +28,7 @@
 UPDATE Certificates SET CertificateData = JSON_MODIFY(JSON_MODIFY(CertificateData, '$.ProviderName', ''), '$.FullName', JSON_VALUE(CertificateData, '$.LearnerGivenNames') + ' ' + JSON_VALUE(CertificateData, '$.LearnerFamilyName'))
 
 -- Update existing StandardLevel to remove the word "Level"
-UPDATE Certificates SET CertificateData = JSON_MODIFY(CertificateData, '$.StandardLevel', SUBSTRING(JSON_VALUE(CertificateData, '$.StandardLevel'), 7, 1))
+UPDATE Certificates SET CertificateData = JSON_MODIFY(CertificateData, '$.StandardLevel', SUBSTRING(JSON_VALUE(CertificateData, '$.StandardLevel'), 7, 1)) WHERE CreatedBy = 'Manual'
 
 -- Create a database master key if one does not already exist, using your own password. This key is used to encrypt the credential secret in next step.
 CREATE MASTER KEY ENCRYPTION BY PASSWORD = 'Baldy N3rd Face';

--- a/LoadCertificateData.sql
+++ b/LoadCertificateData.sql
@@ -27,6 +27,8 @@
 -- Update existing Certificate Records with FullName and a placeholder for ProviderName
 UPDATE Certificates SET CertificateData = JSON_MODIFY(JSON_MODIFY(CertificateData, '$.ProviderName', ''), '$.FullName', JSON_VALUE(CertificateData, '$.LearnerGivenNames') + ' ' + JSON_VALUE(CertificateData, '$.LearnerFamilyName'))
 
+-- Update existing StandardLevel to remove the word "Level"
+UPDATE Certificates SET CertificateData = JSON_MODIFY(CertificateData, '$.StandardLevel', SUBSTRING(JSON_VALUE(CertificateData, '$.StandardLevel'), 7, 1))
 
 -- Create a database master key if one does not already exist, using your own password. This key is used to encrypt the credential secret in next step.
 CREATE MASTER KEY ENCRYPTION BY PASSWORD = 'Baldy N3rd Face';

--- a/LoadCertificateData.sql
+++ b/LoadCertificateData.sql
@@ -29,7 +29,7 @@ CREATE MASTER KEY ENCRYPTION BY PASSWORD = 'Baldy N3rd Face';
 ---- Create a database scoped credential with Azure storage account key as the secret.
 CREATE DATABASE SCOPED CREDENTIAL BlobCredential 
 WITH IDENTITY = 'SHARED ACCESS SIGNATURE', 
-SECRET = 'sv=2017-07-29&ss=bfqt&srt=sco&sp=rwdlacup&se=2018-05-23T16:59:08Z&st=2018-05-23T08:59:08Z&spr=https&sig=rKoFdgab4dzyDRGVTONrKbWLbMOViuhzYGzMb7Ctr5Y%3D';
+SECRET = '';
 
 ---- Create an external data source with CREDENTIAL option.
 CREATE EXTERNAL DATA SOURCE BlobStorage WITH (


### PR DESCRIPTION
Covers th following from the ticket:
1) To include the "Full Name" field on the Spreadsheet as "FullName" in the CertificateData json object, for all previously imported and new Certificates.
2) Where the ULN does not match to a current ILR record, and hence cannot lookup GivenNames and FamilyName, to decompose the Full Name as RIGHT Word (inclusive of Hyphens) = FamilyName, remainder = GivenNames.
3) Where the ULN is 9999999999 (which it should not be!) do not to attempt to match to ILR record 
4) Include all Certificates, including where Source = "Other" and not just Source ="ILR" - there may be an ILR record for these (as "Other" may / may not be correct); Step 2 will handle the completion of the name fields.
5) Also, note that Provider UKPRN is not always given for "Other", so should also add the "Provider Name" to CertificateData object as "ProviderName"
(I suggest we add "ProviderName" for all existing certificates, and then we can later get this via Provider Events API  using UKRPN for all newly created Certificates.
7) Handle "NOT APPLICABLE" in "Overall Grade" ==> "NO GRADE AWARDED" (Check exact wording)
8) The standard level data value has been imported as "LEVEL 2" and should be "2" - this needs to be corrected on all Certificates previously Imported.