### PR TITLE
AssessmentDeliveryTeam reports access denied fix

### DIFF
--- a/src/SFA.DAS.AssessorService.Web.Staff/Views/Dashboard/Index.cshtml
+++ b/src/SFA.DAS.AssessorService.Web.Staff/Views/Dashboard/Index.cshtml
@@ -28,7 +28,7 @@
     </div>
 </div>
 <div class="grid-row">
-    <div class="column-one-third" sfa-show-for-roles="@string.Join(",", Roles.OperationsTeam, Roles.CertificationTeam, Roles.AssessmentDeliveryTeam))">
+    <div class="column-one-third" sfa-show-for-roles="@string.Join(",", Roles.OperationsTeam, Roles.CertificationTeam, Roles.AssessmentDeliveryTeam)">
         <h2 class="heading-medium"><a asp-controller="Reports">Reports</a></h2>
         <p>On demand reporting.</p>
     </div>


### PR DESCRIPTION
One extra closing bracket was the problem.  The code that decides whether to show the section or not was looking for "EPA)" instead of "EPA".