### PR TITLE
Change UKPRN field in RoATP API requests to string

### DIFF
--- a/src/SFA.DAS.AssessorService.Api.Types/Models/Roatp/CreateOrganisationRequest.cs
+++ b/src/SFA.DAS.AssessorService.Api.Types/Models/Roatp/CreateOrganisationRequest.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.AssessorService.Api.Types.Models.Roatp
     {
         public int ProviderTypeId { get; set; }
         public int OrganisationTypeId { get; set; }
-        public long Ukprn { get; set; }
+        public string Ukprn { get; set; }
         public string LegalName { get; set; }
         public string TradingName { get; set; }
         public DateTime StatusDate { get; set; }

--- a/src/SFA.DAS.AssessorService.Api.Types/Models/Roatp/DuplicateUKPRNCheckRequest.cs
+++ b/src/SFA.DAS.AssessorService.Api.Types/Models/Roatp/DuplicateUKPRNCheckRequest.cs
@@ -6,6 +6,6 @@
     public class DuplicateUKPRNCheckRequest : IRequest
     {
         public Guid OrganisationId { get; set; }
-        public long UKPRN { get; set; }
+        public string UKPRN { get; set; }
     }
 }

--- a/src/SFA.DAS.AssessorService.Api.Types/Models/Roatp/Organisation.cs
+++ b/src/SFA.DAS.AssessorService.Api.Types/Models/Roatp/Organisation.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.AssessorService.Api.Types.Models.Roatp
         public Guid Id { get; set; }
         public ProviderType ProviderType { get; set; }
         public OrganisationType OrganisationType { get; set; }
-        public long UKPRN { get; set; }
+        public string UKPRN { get; set; }
         public string LegalName { get; set; }
         public string TradingName { get; set; }
         public OrganisationStatus OrganisationStatus { get; set; }

--- a/src/SFA.DAS.AssessorService.Web.Staff/Controllers/Roatp/AddRoatpOrganisationController.cs
+++ b/src/SFA.DAS.AssessorService.Web.Staff/Controllers/Roatp/AddRoatpOrganisationController.cs
@@ -140,7 +140,7 @@ namespace SFA.DAS.AssessorService.Web.Staff.Controllers.Roatp
                 ParentCompanyGuarantee = false,
                 ProviderTypeId = model.ProviderTypeId,
                 StatusDate = DateTime.Now,
-                Ukprn = Convert.ToInt64(model.UKPRN),
+                Ukprn = model.UKPRN,
                 TradingName = model.TradingName,
                 Username = HttpContext.User.OperatorName()
             };


### PR DESCRIPTION
This prevents valid UKPRN values from being rejected by WAF parsing rules
