### PR TITLE
Amendments to the sandbox-template.json

### DIFF
--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -38,16 +38,13 @@
         "externalApiActiveSandboxAppServiceName": {
             "type": "string"
         },
-        "certificateName": {
-            "type": "string"
-        },
         "internalApiSandboxAppServiceName": {
             "type": "string"
         },
         "internalApiSandboxCustomHostName": {
             "type": "string"
         },
-        "sandBoxFunctionAppNames": {
+        "sandboxFunctionAppNames": {
             "type": "array"
         },
         "sharedSqlResourceGroup": {
@@ -76,6 +73,15 @@
         },
         "externalActiveApiSandboxCustomHostname": {
             "type": "string"
+        },
+        "externalApiSandboxAppServiceCertificateName": {
+           "type": "string"
+        },
+        "internalApiSandboxAppServiceCertificateName": {
+           "type": "string"
+        },
+        "sandboxFunctionAppStorageAccountName": {
+           "type": "string"
         }
     },
     "variables": {
@@ -118,7 +124,55 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "[concat('AppService-', parameters('externalApiActiveSandboxAppServiceName'))]",
+            "name": "external-app-service-certificate",
+            "type": "Microsoft.Resources/deployments",
+            "condition": "[greater(length(parameters('externalApiSandboxAppServiceCertificateName')), 0)]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-certificate.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultCertificateName": {
+                        "value": "[parameters('externalApiSandboxAppServiceCertificateName')]"
+                    },
+                    "keyVaultName": {
+                        "value": "[parameters('sharedKeyVaultName')]"
+                    },
+                    "keyVaultResourceGroup": {
+                        "value": "[parameters('sharedManagementResourceGroup')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "internal-app-service-certificate",
+            "type": "Microsoft.Resources/deployments",
+            "condition": "[greater(length(parameters('internalApiSandboxAppServiceCertificateName')), 0)]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-certificate.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultCertificateName": {
+                        "value": "[parameters('internalApiSandboxAppServiceCertificateName')]"
+                    },
+                    "keyVaultName": {
+                        "value": "[parameters('sharedKeyVaultName')]"
+                    },
+                    "keyVaultResourceGroup": {
+                        "value": "[parameters('sharedManagementResourceGroup')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "[concat('app-service-', parameters('externalApiActiveSandboxAppServiceName'))]",
             "type": "Microsoft.Resources/deployments",
             "condition": "[parameters('deploySandbox')]",
             "properties": {
@@ -174,7 +228,7 @@
                         "value": "[parameters('externalActiveApiSandboxCustomHostname')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[if(greater(length(parameters('certificateName')), 0), reference('app-service-certificate').outputs.certificateThumbprint.value, '')]"
+                        "value": "[if(greater(length(parameters('externalApiSandboxAppServiceCertificateName')), 0), reference('external-app-service-certificate').outputs.certificateThumbprint.value, '')]"
                     }
                 }
             },
@@ -183,31 +237,7 @@
             ]
         },
         {
-            "apiVersion": "2017-05-10",
-            "name": "app-service-certificate",
-            "type": "Microsoft.Resources/deployments",
-            "condition": "[greater(length(parameters('certificateName')), 0)]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-certificate.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "keyVaultCertificateName": {
-                        "value": "[parameters('certificateName')]"
-                    },
-                    "keyVaultName": {
-                        "value": "[parameters('sharedKeyVaultName')]"
-                    },
-                    "keyVaultResourceGroup": {
-                        "value": "[parameters('sharedManagementResourceGroup')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "[concat('AppService-', parameters('internalApiSandboxAppServiceName'))]",
+            "name": "[concat('app-service-', parameters('internalApiSandboxAppServiceName'))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2017-05-10",
             "condition": "[parameters('deploySandbox')]",
@@ -256,7 +286,7 @@
                         "value": "[parameters('internalApiSandboxCustomHostName')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[if(greater(length(parameters('certificateName')), 0), reference('app-service-certificate').outputs.certificateThumbprint.value, '')]"
+                        "value": "[if(greater(length(parameters('internalApiSandboxAppServiceCertificateName')), 0), reference('internal-app-service-certificate').outputs.certificateThumbprint.value, '')]"
                     }
                 }
             },
@@ -265,7 +295,25 @@
             ]
         },
         {
-            "name": "[concat('FunctionApp-', parameters('sandBoxFunctionAppNames')[copyIndex()])]",
+            "name": "storage-account",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2017-05-10",
+            "condition": "[parameters('deploySandbox')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/storage-account-arm.json",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "storageAccountName": {
+                        "value": "[parameters('sandboxFunctionAppStorageAccountName')]"
+                    }
+                }
+            }
+        },
+        {
+            "name": "[concat('function-app-', parameters('sandboxFunctionAppNames')[copyIndex()])]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2017-05-10",
             "condition": "[parameters('deploySandbox')]",
@@ -277,7 +325,7 @@
                 },
                 "parameters": {
                     "functionAppName": {
-                        "value": "[parameters('sandBoxFunctionAppNames')[copyIndex()]]"
+                        "value": "[parameters('sandboxFunctionAppNames')[copyIndex()]]"
                     },
                     "appServicePlanName": {
                         "value": "[parameters('activeSandboxAppServicePlanName')]"
@@ -289,11 +337,11 @@
                         "value": [
                             {
                                 "name": "AzureWebJobsStorage",
-                                "value": "[reference('StorageAccount').outputs.StorageConnectionString.value]"
+                                "value": "[reference('storage-account').outputs.StorageConnectionString.value]"
                             },
                             {
                                 "name": "AzureWebJobsDashboard",
-                                "value": "[reference('StorageAccount').outputs.StorageConnectionString.value]"
+                                "value": "[reference('storage-account').outputs.StorageConnectionString.value]"
                             },
                             {
                                 "name": "FUNCTIONS_EXTENSION_VERSION",
@@ -329,11 +377,11 @@
                 }
             },
             "copy": {
-                "name": "FunctionAppCopy",
-                "count": "[length(parameters('sandBoxFunctionAppNames'))]"
+                "name": "function-app-copy",
+                "count": "[length(parameters('sandboxFunctionAppNames'))]"
             },
             "dependsOn": [
-                "StorageAccount"
+                "storage-account"
             ]
         },
         {
@@ -382,7 +430,7 @@
         },
         {
             "apiVersion": "2017-08-01",
-            "name": "[concat(parameters('sandBoxFunctionAppNames')[copyIndex()], '-ai')]",
+            "name": "[concat(parameters('sandboxFunctionAppNames')[copyIndex()], '-ai')]",
             "type": "Microsoft.Resources/deployments",
             "condition": "[parameters('deploySandbox')]",
             "properties": {

--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -85,7 +85,7 @@
         }
     },
     "variables": {
-        "InstanceName": "[if(equals(toUpper(parameters('environmentName')),'PROD'),'',parameters('environmentName'))]",
+        "instanceName": "[if(equals(toUpper(parameters('environmentName')),'PROD'),'',parameters('environmentName'))]",
         "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/"
     },
     "resources": [
@@ -207,7 +207,7 @@
                             },
                             {
                                 "name": "InstanceName",
-                                "value": "[concat(variables('InstanceName'),' (ActiveSandbox)')]"
+                                "value": "[concat(variables('instanceName'),' (ActiveSandbox)')]"
                             },
                             {
                                 "name": "UseSandboxServices",
@@ -302,7 +302,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/storage-account-arm.json",
+                    "uri": "[concat(variables('deploymentUrlBase'), 'storage-account-arm.json')]",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {

--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -124,7 +124,7 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "external-app-service-certificate",
+            "name": "sandbox-external-app-service-certificate",
             "type": "Microsoft.Resources/deployments",
             "condition": "[greater(length(parameters('externalApiSandboxAppServiceCertificateName')), 0)]",
             "properties": {
@@ -148,7 +148,7 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "internal-app-service-certificate",
+            "name": "sandbox-internal-app-service-certificate",
             "type": "Microsoft.Resources/deployments",
             "condition": "[greater(length(parameters('internalApiSandboxAppServiceCertificateName')), 0)]",
             "properties": {
@@ -228,7 +228,7 @@
                         "value": "[parameters('externalActiveApiSandboxCustomHostname')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[if(greater(length(parameters('externalApiSandboxAppServiceCertificateName')), 0), reference('external-app-service-certificate').outputs.certificateThumbprint.value, '')]"
+                        "value": "[if(greater(length(parameters('externalApiSandboxAppServiceCertificateName')), 0), reference('sandbox-external-app-service-certificate').outputs.certificateThumbprint.value, '')]"
                     }
                 }
             },
@@ -286,7 +286,7 @@
                         "value": "[parameters('internalApiSandboxCustomHostName')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[if(greater(length(parameters('internalApiSandboxAppServiceCertificateName')), 0), reference('internal-app-service-certificate').outputs.certificateThumbprint.value, '')]"
+                        "value": "[if(greater(length(parameters('internalApiSandboxAppServiceCertificateName')), 0), reference('sandbox-internal-app-service-certificate').outputs.certificateThumbprint.value, '')]"
                     }
                 }
             },
@@ -295,7 +295,7 @@
             ]
         },
         {
-            "name": "storage-account",
+            "name": "sandbox-storage-account",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2017-05-10",
             "condition": "[parameters('deploySandbox')]",
@@ -337,11 +337,11 @@
                         "value": [
                             {
                                 "name": "AzureWebJobsStorage",
-                                "value": "[reference('storage-account').outputs.StorageConnectionString.value]"
+                                "value": "[reference('sandbox-storage-account').outputs.StorageConnectionString.value]"
                             },
                             {
                                 "name": "AzureWebJobsDashboard",
-                                "value": "[reference('storage-account').outputs.StorageConnectionString.value]"
+                                "value": "[reference('sandbox-storage-account').outputs.StorageConnectionString.value]"
                             },
                             {
                                 "name": "FUNCTIONS_EXTENSION_VERSION",
@@ -381,7 +381,7 @@
                 "count": "[length(parameters('sandboxFunctionAppNames'))]"
             },
             "dependsOn": [
-                "storage-account"
+                "sandbox-storage-account"
             ]
         },
         {


### PR DESCRIPTION
The following amendments have been made to the sandbox-template.json file:

- There are two App Service deployments (internal and external) which were referencing the one Certificate resource deployment to get the thumbprint output. This worked when using the wildcard certificate, however in order to support two different custom hostnames in PROD I have amended the template to include two Certificate resource deployments. The certificateName parameter has been removed and replaced with two additional parameters; externalApiSandboxAppServiceCertificateName and internalApiSandboxAppServiceCertificateName.
- Added a new Storage Account resource deployment to create a new storage account for the new sandbox function app. A new parameter has been added sandboxFunctionAppStorageAccountName.
- Minor casing changes.
- Minor resource deployment name changes.