### PR TITLE
Removed aspLocation parameter from the sandbox-app-service-plan resource deployment.

### DIFF
--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -110,9 +110,6 @@
                       "aseResourceGroup": {
                         "value": "[parameters('aseResourceGroup')]"
                     },
-                    "aspLocation": {
-                        "value": "[resourceGroup().location]"
-                    },
                     "aspSize": {
                         "value": "[parameters('aspSize')]"
                     },


### PR DESCRIPTION
Removed aspLocation parameter from the sandbox-app-service-plan resource deployment. This is because it was referencing the location of the resource group which returns "westeurope" however the building block template only allows the value "West Europe". The pipeline logs would return the following:

`Deployment template validation failed: 'The provided value 'westeurope' for the template parameter 'aspLocation' at line '8' and column '20' is not valid. The parameter value is not part of the allowed value(s): 'North Europe,West Europe'.'.",`