### PR TITLE
Changed aspInstances parameter type from string to int to match building block template.

### DIFF
--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -33,7 +33,7 @@
             "type": "string"
         },
         "aspInstances": {
-            "type": "string"
+            "type": "int"
         },
         "externalApiActiveSandboxAppServiceName": {
             "type": "string"


### PR DESCRIPTION
The resource deployments of the web and function apps are dependent on the sandbox-app-service-plan resource deployment, however the deployment fails due to the aspInstances parameter being type string rather than int. The building block template app-service-plan.json requires a int type for the aspInstances parameter. The deployment fails with: 

> "Deployment template validation failed: 'The provided value for the template parameter 'aspInstances' at line '32' and column '21' is not valid.'."