### PR TITLE
Added resourceGroup to the certificate resource deployments.

### DIFF
--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -122,6 +122,7 @@
         {
             "apiVersion": "2017-05-10",
             "name": "sandbox-external-app-service-certificate",
+            "resourceGroup": "[parameters('sharedManagementResourceGroup')]",
             "type": "Microsoft.Resources/deployments",
             "condition": "[greater(length(parameters('externalApiSandboxAppServiceCertificateName')), 0)]",
             "properties": {
@@ -146,6 +147,7 @@
         {
             "apiVersion": "2017-05-10",
             "name": "sandbox-internal-app-service-certificate",
+            "resourceGroup": "[parameters('sharedManagementResourceGroup')]",
             "type": "Microsoft.Resources/deployments",
             "condition": "[greater(length(parameters('internalApiSandboxAppServiceCertificateName')), 0)]",
             "properties": {


### PR DESCRIPTION
Added resourceGroup to certificate resource deployments due to error in Azure DevOps deployment logs for the App Service deployments.

`"message": "{\r\n  \"Code\": \"NotFound\",\r\n  \"Message\": \"Certificate D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2 was not found.\",\r\n `