### PR TITLE
Added sandboxSqlDbConnectionString to the Internal Sandbox API Web App.

### DIFF
--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -82,6 +82,9 @@
         },
         "sandboxFunctionAppStorageAccountName": {
             "type": "string"
+        },
+        "sandboxSqlDbConnectionString": {
+            "type": "string"
         }
     },
     "variables": {
@@ -284,6 +287,11 @@
                             {
                                 "name": "Redis",
                                 "connectionString": "[parameters('loggingRedisConnectionString')]",
+                                "type": "Custom"
+                            },
+                            {
+                                "name": "SandboxSqlDbConnectionString",
+                                "connectionString": "[parameters('sandboxSqlDbConnectionString')]",
                                 "type": "Custom"
                             }
                         ]


### PR DESCRIPTION
The sandbox API web app requires connectivity to the sandbox SQL database das-pp-ass-sbox-db. In order to do this the sandbox-template.json file has been amended with the following:

- Added sandboxSqlDbConnectionString parameter to sandbox-template.json.
- sandboxSqlDbConnectionString parameter added to the appServiceConnectionStrings section of the internal API web app resource deployment section.