### PR TITLE
Changed FUNCTIONS_EXTENSION_VERSION to ~2

### DIFF
--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -363,7 +363,7 @@
                             },
                             {
                                 "name": "FUNCTIONS_EXTENSION_VERSION",
-                                "value": "~1"
+                                "value": "~2"
                             },
                             {
                                 "name": "MSDEPLOY_RENAME_LOCKED_FILES",


### PR DESCRIPTION
The Assessors Sandbox API function app in PREPROD was targeting v1 run time but needs to be v2. The following errors appear when viewing the function app in the Azure Portal:

- `Error: The function type name is invalid.`
- `Error: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.`