### PR TITLE
On 2326 delete certificate stored proc

### DIFF
--- a/src/SFA.DAS.AssessorService.Database/SFA.DAS.AssessorService.Database.sqlproj
+++ b/src/SFA.DAS.AssessorService.Database/SFA.DAS.AssessorService.Database.sqlproj
@@ -130,6 +130,7 @@
     <Build Include="StoredProcedures\OppFinder_Get_Approved_Standard_Details.sql" />
     <Build Include="Tables\ExpressionsOfInterest.sql" />
     <Build Include="StoredProcedures\StaffReports_ExpressionsOfInterest.sql" />
+    <Build Include="StoredProcedures\Delete_Certificate.sql" />
   </ItemGroup>
   <ItemGroup>
     <RefactorLog Include="SFA.DAS.AssessorService.Database.refactorlog" />

--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/Delete_Certificate.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/Delete_Certificate.sql
@@ -1,0 +1,35 @@
+-- Soft Delete a certificates Record
+CREATE PROCEDURE [Delete_Certificate] 
+@CertificateID Int
+AS
+
+
+UPDATE certificates 
+SET [status] = 'Deleted', [DeletedBy] = 'manual', [DeletedAt] = GETDATE() , [IsPrivatelyFunded] = 0, [PrivatelyFundedStatus] = NULL
+WHERE [certificatereferenceid] = @CertificateID;
+
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.ContactName',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.ContactOrganisation',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.ContactAddLine1',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.ContactAddLine2',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.ContactAddLine3',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.ContactAddLine4',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.ContactPostCode',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.AchievementDate',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.CourseOption',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.OverallGrade',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.Department',null) WHERE [certificatereferenceid] = @CertificateID;
+UPDATE certificates SET [CertificateData] = JSON_MODIFY([CertificateData],'strict $.EpaDetails',null) WHERE [certificatereferenceid] = @CertificateID;
+
+
+-- log diffs since last change - these will have been manually amended
+INSERT INTO [CertificateLogs] ([ID],[Action],[CertificateId],[EventTime],[Status],[CertificateData],[Username],[BatchNumber],[ReasonforChange])
+SELECT NEWID() Id, 'Deleted' [Action],ce.[id] [CertificateId], 
+GETDATE() [EventTime], ce.[Status], ce.[CertificateData], 'manual' [Username], ce.[BatchNumber], 'Deleted'
+ FROM [Certificates] ce 
+ LEFT JOIN [CertificateLogs] lgs 
+ ON lgs.CertificateId = ce.Id AND lgs.Action = 'Deleted'  AND lgs.EventTime > DATEADD(day, DATEDIFF(day, 0, GETDATE()), 0)
+ WHERE [certificatereferenceid] = @CertificateID
+  AND lgs.Id IS NULL;
+
+

--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/Delete_Certificate.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/Delete_Certificate.sql
@@ -1,4 +1,6 @@
 -- Soft Delete a certificates Record
+-- this is for manual use only, and not for programatic use
+-- as will need to know the user that is deleting the certificate
 CREATE PROCEDURE [Delete_Certificate] 
 @CertificateID Int
 AS


### PR DESCRIPTION
This stored proc is ONLY for manual execution (by DevOps), to ensure that a Certificate is correctly 'soft' deleted