### PR TITLE
Updated the Internal API App Service to use a Certificate Resource Deployment

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -67,6 +67,12 @@
         },
         "loggingRedisConnectionString": {
             "type": "securestring"
+        },
+        "keyVaultResourceGroupName": {
+            "type": "string"
+        },
+        "keyVaultName": {
+            "type": "string"
         }
     },
     "variables": {
@@ -129,6 +135,34 @@
             }
         },
         {
+            "condition": "[greater(length(parameters('apiCustomHostName')), 0)]",
+            "apiVersion": "2017-05-10",
+            "name": "api-app-service-certificate",
+            "resourceGroup": "[parameters('sharedAppServicePlanResourceGroup')]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-certificate.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultCertificateName": {
+                        "value": "[parameters('apiKeyvaultCertificateName')]"
+                    },
+                    "keyVaultName": {
+                        "value": "[parameters('keyVaultName')]"
+                    },
+                    "keyVaultResourceGroup": {
+                        "value": "[parameters('keyVaultResourceGroupName')]"
+                    },
+                    "serverFarmId": {
+                        "value": "[resourceId(parameters('sharedAppServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('sharedAppServicePlanName'))]"
+                    }
+                }
+            }
+        },
+        {
             "name": "[concat('AppService-', parameters('apiAppServiceName'))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2017-05-10",
@@ -185,10 +219,13 @@
                         "value": "[parameters('apiCustomHostname')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[reference(resourceId(parameters('sharedAppServicePlanResourceGroup'), 'Microsoft.Web/certificates', parameters('apiKeyvaultCertificateName')), '2016-03-01').Thumbprint]"
+                        "value": "[if(greater(length(parameters('apiCustomHostname')), 0), reference('api-app-service-certificate', '2018-11-01').outputs.certificateThumbprint.value, '')]"
                     }
                 }
-            }
+            },
+            "dependsOn": [
+                "api-app-service-certificate"
+            ]
         },
         {
             "apiVersion": "2017-05-10",


### PR DESCRIPTION
For DASD-6869 the ARM template `azure/template.json` has been updated with the following to ensure the appropriate certificate from the shared key vault is deployed into the shared resource group:

- Added `keyVaultResourceGroupName` and `keyVaultName` parameters.
- Added new resource deployment `api-app-service-certificate` to deploy the appropriate key vault certificate based on parameter `apiKeyvaultCertificateName` to the shared app service resource group.
- Amended the `certificateThumbprint` setting for the internal API App Service deployment to reference the new `api-app-service-certificate` deployment. 
- Added `dependsOn` to the internal API App Service deployment with a dependency on the `api-app-service-certificate` resource deployment.