### PR TITLE
Downgrade version of windows azure to prevent issue with NewtonsoftJs…

### DIFF
--- a/src/SFA.DAS.AssessorService.EpaoImporter/SFA.DAS.AssessorService.EpaoImporter.csproj
+++ b/src/SFA.DAS.AssessorService.EpaoImporter/SFA.DAS.AssessorService.EpaoImporter.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="FreeSpire.Doc" Version="5.7.0" />
     <PackageReference Include="Renci.SshNet.Async" Version="1.2.0" />
     <PackageReference Include="NBuilder" Version="5.0.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.AssessorService.Application.Api.Client\SFA.DAS.AssessorService.Application.Api.Client.csproj" />


### PR DESCRIPTION
…on package which occurred preventing the running of the azure functions. This is a recommended workaround as per: https://github.com/Azure/azure-functions-vs-build-sdk/issues/194