### PR TITLE
The delete duplicate certificates script is failing. Due to the time …

### DIFF
--- a/src/SFA.DAS.AssessorService.Database/Script.PostDeployment1.sql
+++ b/src/SFA.DAS.AssessorService.Database/Script.PostDeployment1.sql
@@ -84,7 +84,7 @@ END
 :r .\Insert-Postcode-to-Regions.sql
 
 -- ON-2222 - remove duplicated certs
-:r .\Delete-Duplicated-Certs.sql
+--:r .\Delete-Duplicated-Certs.sql
 
 /* START OF ON-2033 */
 :r .\PostDeploymentScripts\on-2033-anytime_updates.sql


### PR DESCRIPTION
…sensitive nature of the release we are going to remove temporarily and re-add in once the issue is identified.