### PR TITLE
QUAL-51 Fixes error on signout after session expired

### DIFF
--- a/src/SFA.DAS.AssessorService.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/AccountController.cs
@@ -101,6 +101,12 @@ namespace SFA.DAS.AssessorService.Web.Controllers
         {
             ResetCookies();
 
+            if(!User.Identity.IsAuthenticated)
+            {
+                // If they are no longer authenticated then the cookie has expired. Don't try to signout.
+                return RedirectToAction(nameof(HomeController.Index), "Home");
+            }
+
             return SignOut(
                 CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme);
         }


### PR DESCRIPTION
The session is setup for one hour. Once the session expires the authentication cookies are deleted automatically. At this point if user tries to signout, the login service throws a fit due to absence of the session identifier. 

To mitigate this, we call signout only if the user is still authenticated otherwise we just navigate back to home page.  