### PR TITLE
CON-2418 Adds additional validation of completion status to the api

### DIFF
--- a/src/SFA.DAS.AssessorService.Api.Types/Models/ExternalApi/Certificates/BatchCertificateRequest.cs
+++ b/src/SFA.DAS.AssessorService.Api.Types/Models/ExternalApi/Certificates/BatchCertificateRequest.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.AssessorService.Api.Types.Models.ExternalApi.Certificates
 
         public int StandardCode { get; set; }
         public string StandardReference { get; set; }
-
+        public int? StandardId { get; set; }
         public int UkPrn { get; set; }
 
         public string CertificateReference { get; set; }

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/Certificates/CreateBatchCertificateRequestValidator/WhenCompletionStatusIsInvalid.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/Certificates/CreateBatchCertificateRequestValidator/WhenCompletionStatusIsInvalid.cs
@@ -1,0 +1,51 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using FluentValidation.Results;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models.ExternalApi.Certificates;
+using SFA.DAS.AssessorService.Domain.Consts;
+using SFA.DAS.AssessorService.Domain.JsonData;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Validators.ExternalApi.Certificates.CreateBatchCertificateRequestValidator
+{
+    public class WhenCompletionStatusIsInvalid : CreateBatchCertificateRequestValidatorTestBase
+    {
+        private ValidationResult _validationResult;
+
+        [Test]
+        public async Task ThenValidationResultShouldBeFalse()
+        {
+
+            var request = CreateInvalidRequest();
+
+            _validationResult = await Validator.ValidateAsync(request);
+
+            _validationResult.IsValid.Should().BeFalse();
+            _validationResult.Errors.Count.Should().Be(1);
+        }
+
+        private CreateBatchCertificateRequest CreateInvalidRequest()
+        {
+            CreateBatchCertificateRequest request = Builder<CreateBatchCertificateRequest>.CreateNew()
+               .With(i => i.Uln = 1234567891)
+               .With(i => i.StandardCode = 1)
+               .With(i => i.StandardReference = null)
+               .With(i => i.UkPrn = 12345678)
+               .With(i => i.FamilyName = "Test")
+               .With(i => i.CertificateReference = null)
+               .With(i => i.CertificateData = Builder<CertificateData>.CreateNew()
+                               .With(cd => cd.ContactPostCode = "AA11AA")
+                               .With(cd => cd.AchievementDate = DateTime.UtcNow)
+                               .With(cd => cd.OverallGrade = CertificateGrade.Pass)
+                               .With(cd => cd.CourseOption = null)
+                               .Build())
+               .Build();
+
+            return request;
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/Epas/CreateBatchEpaRequestValidator/WhenLearnerHasTemporarilyWithdrawnFromTheILR.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/Epas/CreateBatchEpaRequestValidator/WhenLearnerHasTemporarilyWithdrawnFromTheILR.cs
@@ -1,0 +1,46 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using FluentValidation.Results;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models.ExternalApi.Epas;
+using SFA.DAS.AssessorService.Domain.Consts;
+using SFA.DAS.AssessorService.Domain.JsonData;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Validators.ExternalApi.Epas.CreateBatchEpaRequestValidator
+{
+    public class WhenLearnerHasTemporarilyWithdrawnFromTheILR : CreateBatchEpaRequestValidatorTestBase
+    {
+        private ValidationResult _validationResult;
+
+        [SetUp]
+        public async Task Arrange()
+        {
+            var epas = Builder<EpaRecord>.CreateListOfSize(1).All()
+                .With(i => i.EpaDate = DateTime.UtcNow.AddDays(-1))
+                .With(i => i.EpaOutcome = EpaOutcome.Pass)
+                .Build().ToList();
+
+            var request = Builder<CreateBatchEpaRequest>.CreateNew()
+                .With(i => i.Uln = 1234567892)
+                .With(i => i.StandardCode = 1)
+                .With(i => i.StandardReference = null)
+                .With(i => i.UkPrn = 12345678)
+                .With(i => i.FamilyName = "Test")
+                .With(i => i.EpaDetails = new EpaDetails { Epas = epas })
+                .Build();
+
+            _validationResult = await Validator.ValidateAsync(request);
+        }
+
+        [Test]
+        public void ThenValidationResultShouldBeFalse()
+        {
+            _validationResult.IsValid.Should().BeFalse();
+            _validationResult.Errors.Count.Should().Be(1);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/Epas/CreateBatchEpaRequestValidator/WhenLearnerHasWithdrawnFromTheILR.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/Epas/CreateBatchEpaRequestValidator/WhenLearnerHasWithdrawnFromTheILR.cs
@@ -1,0 +1,46 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using FluentValidation.Results;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models.ExternalApi.Epas;
+using SFA.DAS.AssessorService.Domain.Consts;
+using SFA.DAS.AssessorService.Domain.JsonData;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Validators.ExternalApi.Epas.CreateBatchEpaRequestValidator
+{
+    public class WhenLearnerHasWithdrawnFromTheILR : CreateBatchEpaRequestValidatorTestBase
+    {
+        private ValidationResult _validationResult;
+
+        [SetUp]
+        public async Task Arrange()
+        {
+            var epas = Builder<EpaRecord>.CreateListOfSize(1).All()
+                .With(i => i.EpaDate = DateTime.UtcNow.AddDays(-1))
+                .With(i => i.EpaOutcome = EpaOutcome.Pass)
+                .Build().ToList();
+
+            var request = Builder<CreateBatchEpaRequest>.CreateNew()
+                .With(i => i.Uln = 1234567891)
+                .With(i => i.StandardCode = 1)
+                .With(i => i.StandardReference = null)
+                .With(i => i.UkPrn = 12345678)
+                .With(i => i.FamilyName = "Test")
+                .With(i => i.EpaDetails = new EpaDetails { Epas = epas })
+                .Build();
+
+            _validationResult = await Validator.ValidateAsync(request);
+        }
+
+        [Test]
+        public void ThenValidationResultShouldBeFalse()
+        {
+            _validationResult.IsValid.Should().BeFalse();
+            _validationResult.Errors.Count.Should().Be(1);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/ExternalApiValidatorsTestBase.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/ExternalApiValidatorsTestBase.cs
@@ -35,8 +35,9 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Validators.ExternalA
             certificateRepositoryMock.Setup(q => q.GetCertificate(1234567890, 1)).ReturnsAsync(GenerateCertificate(1234567890, 1, "test", CertificateStatus.Draft, new Guid("12345678123456781234567812345678")));
             certificateRepositoryMock.Setup(q => q.GetCertificate(1234567890, 98)).ReturnsAsync(GenerateCertificate(1234567890, 98, "test", CertificateStatus.Deleted, new Guid("12345678123456781234567812345678")));
             certificateRepositoryMock.Setup(q => q.GetCertificate(9999999999, 1)).ReturnsAsync(GenerateCertificate(9999999999, 1, "test", CertificateStatus.Printed, new Guid("99999999999999999999999999999999")));
-
-            // This is simulating a Certificate that started it's life on the Web App, but was never submitted
+            certificateRepositoryMock.Setup(q => q.GetCertificate(1234567890, 99)).ReturnsAsync(GenerateCertificate(1234567890, 99, "Test", CertificateStatus.Draft, new Guid("12345678123456781234567812345678")));
+          
+                // This is simulating a Certificate that started it's life on the Web App, but was never submitted
             certificateRepositoryMock.Setup(q => q.GetCertificate(1234567890, 99)).ReturnsAsync(GeneratePartialCertificate(1234567890, 99, "test", new Guid("12345678123456781234567812345678"), null));
             certificateRepositoryMock.Setup(q => q.GetCertificate(9999999999, 99)).ReturnsAsync(GeneratePartialCertificate(9999999999, 99, "test", new Guid("99999999999999999999999999999999"), CertificateGrade.Fail));
 
@@ -110,17 +111,19 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Validators.ExternalA
         {
             var ilrRepositoryMock = new Mock<IIlrRepository>();
 
-            ilrRepositoryMock.Setup(q => q.Get(1234567890, 1)).ReturnsAsync(GenerateIlr(1234567890, 1, "Test", "12345678"));
-            ilrRepositoryMock.Setup(q => q.Get(1234567890, 98)).ReturnsAsync(GenerateIlr(1234567890, 98, "Test", "12345678"));
-            ilrRepositoryMock.Setup(q => q.Get(1234567890, 99)).ReturnsAsync(GenerateIlr(1234567890, 99, "Test", "12345678"));
-            ilrRepositoryMock.Setup(q => q.Get(1234567890, 101)).ReturnsAsync(GenerateIlr(1234567890, 101, "Test", "12345678"));
-            ilrRepositoryMock.Setup(q => q.Get(9999999999, 1)).ReturnsAsync(GenerateIlr(9999999999, 1, "Test", "99999999"));
-            ilrRepositoryMock.Setup(q => q.Get(9999999999, 99)).ReturnsAsync(GenerateIlr(9999999999, 99, "Test", "99999999"));
-            ilrRepositoryMock.Setup(q => q.Get(9999999999, 101)).ReturnsAsync(GenerateIlr(9999999999, 101, "Test", "99999999"));
+            ilrRepositoryMock.Setup(q => q.Get(1234567890, 1)).ReturnsAsync(GenerateIlr(1234567890, 1, "Test", "12345678", CompletionStatus.Complete));
+            ilrRepositoryMock.Setup(q => q.Get(1234567890, 98)).ReturnsAsync(GenerateIlr(1234567890, 98, "Test", "12345678", CompletionStatus.Complete));
+            ilrRepositoryMock.Setup(q => q.Get(1234567890, 99)).ReturnsAsync(GenerateIlr(1234567890, 99, "Test", "12345678", CompletionStatus.Complete));
+            ilrRepositoryMock.Setup(q => q.Get(1234567890, 101)).ReturnsAsync(GenerateIlr(1234567890, 101, "Test", "12345678", CompletionStatus.Complete));
+            ilrRepositoryMock.Setup(q => q.Get(9999999999, 1)).ReturnsAsync(GenerateIlr(9999999999, 1, "Test", "99999999", CompletionStatus.Complete));
+            ilrRepositoryMock.Setup(q => q.Get(9999999999, 99)).ReturnsAsync(GenerateIlr(9999999999, 99, "Test", "99999999", CompletionStatus.Complete));
+            ilrRepositoryMock.Setup(q => q.Get(9999999999, 101)).ReturnsAsync(GenerateIlr(9999999999, 101, "Test", "99999999", CompletionStatus.Complete));
 
             // Leave this ILR without a EPA or a Certificate!
-            ilrRepositoryMock.Setup(q => q.Get(5555555555, 1)).ReturnsAsync(GenerateIlr(5555555555, 1, "Test", "12345678"));
+            ilrRepositoryMock.Setup(q => q.Get(5555555555, 1)).ReturnsAsync(GenerateIlr(5555555555, 1, "Test", "12345678", CompletionStatus.Complete));
 
+            ilrRepositoryMock.Setup(q => q.Get(1234567891, 1)).ReturnsAsync(GenerateIlr(1234567891, 1, "Test", "12345678", CompletionStatus.Withdrawn));
+            
             return ilrRepositoryMock;
         }
 
@@ -270,13 +273,14 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Validators.ExternalA
                 .Build();
         }
 
-        private static Ilr GenerateIlr(long uln, int standardCode, string familyName, string epaOrgId)
+        private static Ilr GenerateIlr(long uln, int standardCode, string familyName, string epaOrgId, CompletionStatus completionStatus)
         {
             return Builder<Ilr>.CreateNew()
                 .With(i => i.Uln = uln)
                 .With(i => i.StdCode = standardCode)
                 .With(i => i.FamilyName = familyName)
                 .With(i => i.EpaOrgId = epaOrgId)
+                .With(i => i.CompletionStatus = (int)completionStatus)
                 .Build();
         }
 

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/ExternalApiValidatorsTestBase.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Validators/ExternalApi/ExternalApiValidatorsTestBase.cs
@@ -123,7 +123,8 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Validators.ExternalA
             ilrRepositoryMock.Setup(q => q.Get(5555555555, 1)).ReturnsAsync(GenerateIlr(5555555555, 1, "Test", "12345678", CompletionStatus.Complete));
 
             ilrRepositoryMock.Setup(q => q.Get(1234567891, 1)).ReturnsAsync(GenerateIlr(1234567891, 1, "Test", "12345678", CompletionStatus.Withdrawn));
-            
+            ilrRepositoryMock.Setup(q => q.Get(1234567892, 1)).ReturnsAsync(GenerateIlr(1234567892, 1, "Test", "12345678", CompletionStatus.TemporarilyWithdrawn));
+
             return ilrRepositoryMock;
         }
 

--- a/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Certificates/CreateBatchCertificateRequestValidator.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Certificates/CreateBatchCertificateRequestValidator.cs
@@ -58,11 +58,11 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Certifi
                     {
                         if (learnerDetails.CompletionStatus == (int)CompletionStatus.Withdrawn)
                         {
-                            context.AddFailure(new ValidationFailure("CompletionStatus", "Completion status must not be withdrawn"));
+                            context.AddFailure(new ValidationFailure("LearnerDetails", "Cannot find the apprentice details"));
                         }
                         else if (learnerDetails.CompletionStatus == (int)CompletionStatus.TemporarilyWithdrawn)
                         {
-                            context.AddFailure(new ValidationFailure("CompletionStatus", "Completion status must not be temporarily withdrawn"));
+                            context.AddFailure(new ValidationFailure("LearnerDetails", "Cannot find the apprentice details"));
                         }
                     }
                     else

--- a/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Certificates/CreateBatchCertificateRequestValidator.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Certificates/CreateBatchCertificateRequestValidator.cs
@@ -54,14 +54,22 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Certifi
                         }
                     }
 
-                    if (learnerDetails.CompletionStatus == (int)CompletionStatus.Withdrawn)
+                    if (learnerDetails != null)
                     {
-                        context.AddFailure(new ValidationFailure("CompletionStatus", "Completion status must not be withdrawn"));
+                        if (learnerDetails.CompletionStatus == (int)CompletionStatus.Withdrawn)
+                        {
+                            context.AddFailure(new ValidationFailure("CompletionStatus", "Completion status must not be withdrawn"));
+                        }
+                        else if (learnerDetails.CompletionStatus == (int)CompletionStatus.TemporarilyWithdrawn)
+                        {
+                            context.AddFailure(new ValidationFailure("CompletionStatus", "Completion status must not be temporarily withdrawn"));
+                        }
                     }
-                    else if (learnerDetails.CompletionStatus == (int)CompletionStatus.TemporarilyWithdrawn)
+                    else
                     {
-                        context.AddFailure(new ValidationFailure("CompletionStatus", "Completion status must not be temporarily withdrawn"));
+                        context.AddFailure(new ValidationFailure("LearnerDetails", $"Learner details for ULN: {m.Uln} not found"));
                     }
+                    
                 });
             });
         }

--- a/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Certificates/CreateBatchCertificateRequestValidator.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Certificates/CreateBatchCertificateRequestValidator.cs
@@ -27,6 +27,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Certifi
                 {
                     var existingCertificate = await certificateRepository.GetCertificate(m.Uln, m.StandardCode);
                     var sumbittingEpao = await organisationQueryRepository.GetByUkPrn(m.UkPrn);
+                    var learnerDetails = await ilrRepository.Get(m.Uln, m.StandardId.GetValueOrDefault());
 
                     if (existingCertificate != null && existingCertificate.Status != CertificateStatus.Deleted)
                     {
@@ -51,6 +52,15 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Certifi
                         {
                             context.AddFailure(new ValidationFailure("CertificateData", $"Certificate already exists: {existingCertificate.CertificateReference}"));
                         }
+                    }
+
+                    if (learnerDetails.CompletionStatus == (int)CompletionStatus.Withdrawn)
+                    {
+                        context.AddFailure(new ValidationFailure("CompletionStatus", "Completion status must not be withdrawn"));
+                    }
+                    else if (learnerDetails.CompletionStatus == (int)CompletionStatus.TemporarilyWithdrawn)
+                    {
+                        context.AddFailure(new ValidationFailure("CompletionStatus", "Completion status must not be temporarily withdrawn"));
                     }
                 });
             });

--- a/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Epas/BatchEpaRequestValidator.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Epas/BatchEpaRequestValidator.cs
@@ -39,7 +39,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Epas
                     {
                         var requestedIlr = await ilrRepository.Get(m.Uln, m.StandardCode);
                         var sumbittingEpao = await organisationQueryRepository.GetByUkPrn(m.UkPrn);
-
+                        
                         if (requestedIlr is null || !string.Equals(requestedIlr.FamilyName, m.FamilyName, StringComparison.InvariantCultureIgnoreCase))
                         {
                             context.AddFailure(new ValidationFailure("Uln", "ULN, FamilyName and Standard not found."));
@@ -47,6 +47,14 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Epas
                         else if (sumbittingEpao is null)
                         {
                             context.AddFailure(new ValidationFailure("UkPrn", "Specified UKPRN not found"));
+                        }
+                        else if (requestedIlr.CompletionStatus == (int)CompletionStatus.Withdrawn)
+                        {
+                            context.AddFailure(new ValidationFailure("CompletionStatus", "Completion Status must not be withdrawn"));
+                        }
+                        else if (requestedIlr.CompletionStatus == (int)CompletionStatus.TemporarilyWithdrawn)
+                        {
+                            context.AddFailure(new ValidationFailure("CompletionStatus", "Completion Status must not be temporarily withdrawn"));
                         }
                         else
                         {
@@ -75,6 +83,8 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Epas
                                .Must(epa => outcomes.Contains(epa.EpaOutcome, StringComparer.InvariantCultureIgnoreCase)).WithMessage($"Invalid outcome: must be Pass, Fail or Withdrawn");
                     });
             });
+
+            //RuleFor(m => m.)
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Epas/BatchEpaRequestValidator.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Epas/BatchEpaRequestValidator.cs
@@ -83,8 +83,6 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Epas
                                .Must(epa => outcomes.Contains(epa.EpaOutcome, StringComparer.InvariantCultureIgnoreCase)).WithMessage($"Invalid outcome: must be Pass, Fail or Withdrawn");
                     });
             });
-
-            //RuleFor(m => m.)
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Epas/BatchEpaRequestValidator.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Validators/ExternalApi/Epas/BatchEpaRequestValidator.cs
@@ -50,11 +50,11 @@ namespace SFA.DAS.AssessorService.Application.Api.Validators.ExternalApi.Epas
                         }
                         else if (requestedIlr.CompletionStatus == (int)CompletionStatus.Withdrawn)
                         {
-                            context.AddFailure(new ValidationFailure("CompletionStatus", "Completion Status must not be withdrawn"));
+                            context.AddFailure(new ValidationFailure("LearnerDetails", "Cannot find the apprentice details"));
                         }
                         else if (requestedIlr.CompletionStatus == (int)CompletionStatus.TemporarilyWithdrawn)
                         {
-                            context.AddFailure(new ValidationFailure("CompletionStatus", "Completion Status must not be temporarily withdrawn"));
+                            context.AddFailure(new ValidationFailure("LearnerDetails", "Cannot find the apprentice details"));
                         }
                         else
                         {

--- a/src/SFA.DAS.AssessorService.Application/Handlers/Staff/GetLearnerDetailHandler.cs
+++ b/src/SFA.DAS.AssessorService.Application/Handlers/Staff/GetLearnerDetailHandler.cs
@@ -119,16 +119,16 @@ namespace SFA.DAS.AssessorService.Application.Handlers.Staff
         {
             switch (completionStatus)
             {
-                case 1:
+                case (int)CompletionStatus.Continuing:
                     return $"{completionStatus} - Continuing";
 
-                case 2:
+                case (int)CompletionStatus.Complete:
                     return $"{completionStatus} - Completed";
 
-                case 3:
+                case (int)CompletionStatus.Withdrawn:
                     return $"{completionStatus} - Withdrawn";
 
-                case 6:
+                case (int)CompletionStatus.TemporarilyWithdrawn:
                     return $"{completionStatus} - Temporarily withdrawn";
 
                 default:

--- a/src/SFA.DAS.AssessorService.Data/IlrRepository.cs
+++ b/src/SFA.DAS.AssessorService.Data/IlrRepository.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using SFA.DAS.AssessorService.Application.Interfaces;
 using SFA.DAS.AssessorService.Data.DapperTypeHandlers;
+using SFA.DAS.AssessorService.Domain.Consts;
 using SFA.DAS.AssessorService.Domain.Entities;
 using System;
 using System.Collections.Generic;
@@ -20,10 +21,13 @@ namespace SFA.DAS.AssessorService.Data
 
         public async Task<IEnumerable<Ilr>> SearchForLearnerByUln(long uln)
         {
+            var continuing = (int)CompletionStatus.Continuing;
+            var complete = (int)CompletionStatus.Complete;
+
             return (await _unitOfWork.Connection.QueryAsync<Ilr>(
-                @"SELECT * FROM Ilrs WHERE [Uln] = @uln AND [CompletionStatus] IN (1, 2)",
-                  param: new { uln },
-                  transaction: _unitOfWork.Transaction)).ToList();
+               $@"SELECT * FROM Ilrs WHERE [Uln] = @uln AND [CompletionStatus] IN (@continuing, @complete)",
+                 param: new { uln, continuing, complete },
+                 transaction: _unitOfWork.Transaction)).ToList();
         }
 
         public async Task<Ilr> Get(long uln, int stdCode)

--- a/src/SFA.DAS.AssessorService.Domain/Consts/CompletionStatus.cs
+++ b/src/SFA.DAS.AssessorService.Domain/Consts/CompletionStatus.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SFA.DAS.AssessorService.Domain.Consts
+{
+    public enum CompletionStatus
+    {
+        Continuing = 1,
+        Complete = 2,
+        Withdrawn = 3,
+        TemporarilyWithdrawn = 6
+    }
+}


### PR DESCRIPTION
I have added two new validation rules to the CreateBatchCertificate request validator that will check if the learners completion status is not withdrawn or temporarily withdrawn