### PR TITLE
FAT2-438 Provider not found bug

### DIFF
--- a/src/SFA.DAS.AssessorService.Application/Handlers/Certificates/GetCertificatesHistoryHandler.cs
+++ b/src/SFA.DAS.AssessorService.Application/Handlers/Certificates/GetCertificatesHistoryHandler.cs
@@ -86,9 +86,13 @@ namespace SFA.DAS.AssessorService.Application.Handlers.Certificates
                         if (certificateData.ProviderName == null)
                         {
                             var provider = _roatpApiClient
-                                .GetOrganisationByUkprn(certificate.ProviderUkPrn).GetAwaiter()
-                                .GetResult();
+                                .GetOrganisationByUkprn(certificate.ProviderUkPrn).Result;
 
+                            if (provider == null)
+                            {
+                                throw new EntityNotFoundException($"Provider {certificate.ProviderUkPrn} not found", null);
+                            }
+                            
                             trainingProviderName = provider.ProviderName;
                             _certificateRepository.UpdateProviderName(certificate.Id, trainingProviderName).GetAwaiter().GetResult();
                         }

--- a/src/SFA.DAS.AssessorService.Application/Handlers/Certificates/GetCertificatesToBeApprovedHandler.cs
+++ b/src/SFA.DAS.AssessorService.Application/Handlers/Certificates/GetCertificatesToBeApprovedHandler.cs
@@ -67,6 +67,10 @@ namespace SFA.DAS.AssessorService.Application.Handlers.Certificates
                     if (certificateData.ProviderName == null)
                     {
                         var provider = (await _roatpApiClient.SearchOrganisationByUkprn(certificate.ProviderUkPrn)).FirstOrDefault();
+                        if (provider == null)
+                        {
+                            throw new EntityNotFoundException($"Training provider {certificate.ProviderUkPrn} not found", null);
+                        }
                             
                         trainingProviderName = provider?.ProviderName;
                         await _certificateRepository.UpdateProviderName(certificate.Id, trainingProviderName);

--- a/src/SFA.DAS.AssessorService.Web/Validators/CertificateUkprnViewModelValidator.cs
+++ b/src/SFA.DAS.AssessorService.Web/Validators/CertificateUkprnViewModelValidator.cs
@@ -38,7 +38,11 @@ namespace SFA.DAS.AssessorService.Web.Validators
             try
             {
                 var providerUkprn = Convert.ToInt32(ukprn);
-               _apiClient.GetOrganisationByUkprn(providerUkprn).GetAwaiter().GetResult();
+                var response = _apiClient.GetOrganisationByUkprn(providerUkprn).GetAwaiter().GetResult();
+                if (response == null)
+                {
+                    return false;
+                }
             }
             catch (EntityNotFoundException)
             {


### PR DESCRIPTION
Previous implementation of finding provider from FATv1 relied on an EntityNotFoundException being thrown when the provider didn't exist. Added in logic so that now if the returned item is null then this exception is thrown