### PR TITLE
SV-535 Fix version to be a string in external api response

### DIFF
--- a/src/SFA.DAS.AssessorService.Api.Types/Models/Standards/StandardOptions.cs
+++ b/src/SFA.DAS.AssessorService.Api.Types/Models/Standards/StandardOptions.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.AssessorService.Api.Types.Models.Standards
         public string StandardUId { get; set; }
         public int StandardCode { get; set; }
         public string StandardReference { get; set; }
-        public decimal Version { get; set; }
+        public string Version { get; set; }
         public IEnumerable<string> CourseOption { get; set; }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Models/Response/Standards/StandardOptions.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Models/Response/Standards/StandardOptions.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Models.Response.Stand
     {
         public int? StandardCode { get; set; }
         public string StandardReference { get; set; }
-        public decimal Version { get; set; }
+        public string Version { get; set; }
         public IEnumerable<string> CourseOption { get; set; }
 
         #region GetHashCode, Equals and IEquatable
@@ -21,6 +21,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Models.Response.Stand
 
                 int hash = hashBase;
                 hash = (hash * multiplier) ^ StandardCode.GetHashCode();
+                hash = (hash * multiplier) ^ Version.GetHashCode();
                 hash = (hash * multiplier) ^ (StandardReference is null ? 0 : StandardReference.GetHashCode());
                 hash = (hash * multiplier) ^ (CourseOption is null ? 0 : CourseOption.GetHashCode());
                 return hash;

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
@@ -78,7 +78,7 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
             Assert.AreEqual(result.StandardUId, response.StandardUId);
             Assert.AreEqual(result.StandardCode, response.LarsCode);
             Assert.AreEqual(result.StandardReference, response.IfateReferenceNumber);
-            Assert.AreEqual(result.Version, response.Version);
+            Assert.AreEqual(result.Version, response.Version.ToString("#.0"));
         }
 
         [Test, AutoData]

--- a/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
@@ -102,7 +102,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Services
                     StandardUId = standard.StandardUId,
                     StandardCode = standard.LarsCode,
                     StandardReference = standard.IfateReferenceNumber,
-                    Version = standard.Version,
+                    Version = standard.Version.ToString("#.0"),
                     CourseOption = standard.Options
                 });
             }
@@ -125,7 +125,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Services
                     StandardUId = standard.StandardUId,
                     StandardCode = standard.LarsCode,
                     StandardReference = standard.IfateReferenceNumber,
-                    Version = standard.Version,
+                    Version = standard.Version.ToString("#.0"),
                     CourseOption = standard.Options
                 };
             }


### PR DESCRIPTION
The external API should match the version field to the IFATE API, hence I am converting it  in the internal API. Currently the format in IFATE API is matching to ("#.0"). If this ever changes our code will have to change as well. 