### PR TITLE
SV-537 get standard version options

### DIFF
--- a/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/Controllers/StandardsControllerTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/Controllers/StandardsControllerTests.cs
@@ -36,7 +36,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.UnitTests.Controllers
         }
 
         [Test, MoqAutoData]
-        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionWithOptionsIsFound_Then_ReturnStandard(string standardReference, decimal version, StandardOptions standardOptionsResponse)
+        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionWithOptionsIsFound_Then_ReturnStandard(string standardReference, string version, StandardOptions standardOptionsResponse)
         {
             _mockApiClient.Setup(client => client.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version))
                 .ReturnsAsync(standardOptionsResponse);
@@ -51,7 +51,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.UnitTests.Controllers
         }
 
         [Test, MoqAutoData]
-        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionWithNoOptionsIsFound_Then_ReturnNoContent(string standardReference, decimal version)
+        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionWithNoOptionsIsFound_Then_ReturnNoContent(string standardReference, string version)
         {
             var standardOptionsResponse = _fixture.Build<StandardOptions>()
                 .With(s => s.CourseOption, new List<string>())
@@ -66,7 +66,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.UnitTests.Controllers
         }
 
         [Test, MoqAutoData]
-        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionIsNotFound_Then_ReturnNotFound(string standardReference, decimal version)
+        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionIsNotFound_Then_ReturnNotFound(string standardReference, string version)
         {
             _mockApiClient.Setup(client => client.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version))
                 .ReturnsAsync((StandardOptions)null);

--- a/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/Controllers/StandardsControllerTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/Controllers/StandardsControllerTests.cs
@@ -1,0 +1,80 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Application.Api.External.Controllers;
+using SFA.DAS.AssessorService.Application.Api.External.Infrastructure;
+using SFA.DAS.AssessorService.Application.Api.External.Middleware;
+using SFA.DAS.AssessorService.Application.Api.External.Models.Response.Standards;
+using SFA.DAS.Testing.AutoFixture;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Application.Api.External.UnitTests.Controllers
+{
+    public class StandardsControllerTests
+    {
+        private Fixture _fixture;
+
+        private Mock<IApiClient> _mockApiClient;
+
+        private StandardsController _controller;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _fixture = new Fixture();
+
+            _mockApiClient = new Mock<IApiClient>();
+
+            _controller = new StandardsController(Mock.Of<ILogger<StandardsController>>(), Mock.Of<IHeaderInfo>(), _mockApiClient.Object);
+        }
+
+        [Test, MoqAutoData]
+        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionWithOptionsIsFound_Then_ReturnStandard(string standardReference, decimal version, StandardOptions standardOptionsResponse)
+        {
+            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version))
+                .ReturnsAsync(standardOptionsResponse);
+
+            var result = await _controller.GetOptionsForStandardVersion(standardReference, version) as ObjectResult;
+
+            result.StatusCode.Should().Be((int)HttpStatusCode.OK);
+
+            var model = result.Value as StandardOptions;
+
+            model.Should().BeEquivalentTo(standardOptionsResponse);
+        }
+
+        [Test, MoqAutoData]
+        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionWithNoOptionsIsFound_Then_ReturnNoContent(string standardReference, decimal version)
+        {
+            var standardOptionsResponse = _fixture.Build<StandardOptions>()
+                .With(s => s.CourseOption, new List<string>())
+                .Create();
+
+            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version))
+                .ReturnsAsync(standardOptionsResponse);
+
+            var result = await _controller.GetOptionsForStandardVersion(standardReference, version) as NoContentResult;
+
+            result.StatusCode.Should().Be((int)HttpStatusCode.NoContent);
+        }
+
+        [Test, MoqAutoData]
+        public async Task WhenRequestingStandardVersionOptions_And_StandardVersionIsNotFound_Then_ReturnNotFound(string standardReference, decimal version)
+        {
+            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version))
+                .ReturnsAsync((StandardOptions)null);
+
+            var result = await _controller.GetOptionsForStandardVersion(standardReference, version) as NotFoundResult;
+
+            result.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+        }
+
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/SFA.DAS.AssessorService.Application.Api.External.UnitTests.csproj
+++ b/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/SFA.DAS.AssessorService.Application.Api.External.UnitTests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.106" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.AssessorService.Application.Api.External\SFA.DAS.AssessorService.Application.Api.External.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
@@ -66,5 +66,27 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Controllers
 
             return Ok(requestedStandard);
         }
+
+        [HttpGet("options/{standardReference}/{version}")]
+        [SwaggerResponseExample((int)HttpStatusCode.OK, typeof(SwaggerHelpers.Examples.GetStandardVersionOptionsResponseExample))]
+        [SwaggerResponse((int)HttpStatusCode.OK, "The list of options.", typeof(StandardOptions))]
+        [SwaggerResponse((int)HttpStatusCode.NoContent, "The standard version was found, however it has no options.")]
+        [SwaggerResponse((int)HttpStatusCode.NotFound, "The standard version was not found.")]
+        [SwaggerOperation("Get Options for a standard version", "Gets the latest list of course options for the specified Standard version.", Produces = new string[] { "application/json" })]
+        public async Task<IActionResult> GetOptionsForStandardVersion(string standardReference, decimal version)
+        {
+            var standardVersion = await _apiClient.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+
+            if (standardVersion is null)
+            {
+                return NotFound();
+            }
+            else if (standardVersion.CourseOption is null)
+            {
+                return NoContent();
+            }
+
+            return Ok(standardVersion);
+        }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
@@ -81,7 +81,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Controllers
             {
                 return NotFound();
             }
-            else if (standardVersion.CourseOption is null)
+            else if (standardVersion.CourseOption is null || standardVersion.CourseOption.Any() == false)
             {
                 return NoContent();
             }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
@@ -73,7 +73,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Controllers
         [SwaggerResponse((int)HttpStatusCode.NoContent, "The standard version was found, however it has no options.")]
         [SwaggerResponse((int)HttpStatusCode.NotFound, "The standard version was not found.")]
         [SwaggerOperation("Get Options for a standard version", "Gets the latest list of course options for the specified Standard version.", Produces = new string[] { "application/json" })]
-        public async Task<IActionResult> GetOptionsForStandardVersion(string standardReference, decimal version)
+        public async Task<IActionResult> GetOptionsForStandardVersion(string standardReference, string version)
         {
             var standardVersion = await _apiClient.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
 

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
@@ -226,6 +226,12 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
             return response;
         }
 
+        public virtual async Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, decimal version)
+        {
+            var response = await Get<StandardOptions>($"/api/v1/standard-service/standard-options/{standardReference}/{version}");
+
+            return response;
+        }
 
         public virtual async Task<StandardOptions> GetStandard(string standard)
         {

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
@@ -226,7 +226,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
             return response;
         }
 
-        public virtual async Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, decimal version)
+        public virtual async Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version)
         {
             var response = await Get<StandardOptions>($"/api/v1/standard-service/standard-options/{standardReference}/{version}");
 

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/IApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/IApiClient.cs
@@ -22,6 +22,6 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
 
         Task<IEnumerable<StandardOptions>> GetStandardOptionsList();
         Task<StandardOptions> GetStandardOptionsByStandard(string standard);
-        Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, decimal version);
+        Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version);
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/IApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/IApiClient.cs
@@ -22,5 +22,6 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
 
         Task<IEnumerable<StandardOptions>> GetStandardOptionsList();
         Task<StandardOptions> GetStandardOptionsByStandard(string standard);
+        Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, decimal version);
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/SwaggerHelpers/Examples/GetStandardVersionOptionsResponseExample.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/SwaggerHelpers/Examples/GetStandardVersionOptionsResponseExample.cs
@@ -1,0 +1,13 @@
+﻿using SFA.DAS.AssessorService.Application.Api.External.Models.Response.Standards;
+using Swashbuckle.AspNetCore.Examples;
+
+namespace SFA.DAS.AssessorService.Application.Api.External.SwaggerHelpers.Examples
+{
+    public class GetStandardVersionOptionsResponseExample : IExamplesProvider
+    {
+        public object GetExamples()
+        {
+            return new StandardOptions { StandardCode = 6, StandardReference = "ST0156", Version = 1.0m, CourseOption = new[] { "Overhead lines", "Substation fitting", "Underground cables" } };
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application.Api.External/SwaggerHelpers/Examples/GetStandardVersionOptionsResponseExample.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/SwaggerHelpers/Examples/GetStandardVersionOptionsResponseExample.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.SwaggerHelpers.Exampl
     {
         public object GetExamples()
         {
-            return new StandardOptions { StandardCode = 6, StandardReference = "ST0156", Version = 1.0m, CourseOption = new[] { "Overhead lines", "Substation fitting", "Underground cables" } };
+            return new StandardOptions { StandardCode = 6, StandardReference = "ST0156", Version = "1.0", CourseOption = new[] { "Overhead lines", "Substation fitting", "Underground cables" } };
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/appsettings.json
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/appsettings.json
@@ -13,5 +13,5 @@
   },
   "EnvironmentName": "LOCAL",
   "InstanceName": "LOCAL",
-  "UseSandboxServices": false
+  "UseSandboxServices": true
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/appsettings.json
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/appsettings.json
@@ -13,5 +13,5 @@
   },
   "EnvironmentName": "LOCAL",
   "InstanceName": "LOCAL",
-  "UseSandboxServices": true
+  "UseSandboxServices": false
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
@@ -8,6 +8,7 @@ using SFA.DAS.AssessorService.Api.Types.Models.Standards;
 using SFA.DAS.AssessorService.Application.Api.Services;
 using SFA.DAS.AssessorService.Application.Infrastructure.OuterApi;
 using SFA.DAS.AssessorService.Application.Interfaces;
+using SFA.DAS.AssessorService.Domain.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,6 +20,8 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
     {
         private Mock<IOuterApiClient> _mockOuterApiClient;
         private Mock<ILogger<StandardService>> _mockLogger;
+        private Mock<IStandardRepository> _mockStandardRepository;
+
         private StandardService _standardService;
 
         [SetUp]
@@ -26,11 +29,12 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
         {
             _mockOuterApiClient = new Mock<IOuterApiClient>();
             _mockLogger = new Mock<ILogger<StandardService>>();
+            _mockStandardRepository = new Mock<IStandardRepository>();
 
             _standardService = new StandardService(new CacheService(Mock.Of<IDistributedCache>()),
                 _mockOuterApiClient.Object,
                 _mockLogger.Object,
-                Mock.Of<IStandardRepository>());
+                _mockStandardRepository.Object);
         }
 
         [Test, AutoData]
@@ -92,6 +96,49 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
                     It.IsAny<Exception>(),
                     It.IsAny<Func<object, Exception, string>>()),
                 Times.Once, $"STANDARD OPTIONS: Failed to get standard options for id {id}");
+        }
+
+        [Test, AutoData]
+        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_StandardIsRetrievedFromAssessorStandardsTable(string standardReference, decimal version, Standard getStandardResponse)
+        {
+            _mockStandardRepository.Setup(repository => repository.GetStandardByStandardReferenceAndVersion(standardReference, version))
+                .ReturnsAsync(getStandardResponse);
+
+            await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+
+            _mockStandardRepository.Verify(repository => repository.GetStandardByStandardReferenceAndVersion(standardReference, version), Times.Once);
+        }
+
+        [Test, AutoData]
+        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_And_StandardWithReferenceAndVersionIsNotFound_Then_LogError_And_ReturnNull(string standardReference, decimal version)
+        {
+            _mockStandardRepository.Setup(repository => repository.GetStandardByStandardReferenceAndVersion(It.IsAny<string>(), It.IsAny<decimal>()))
+                .Throws(new Exception());
+
+            var result = await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+            
+            _mockLogger.Verify(logger => logger.Log(LogLevel.Error, It.IsAny<EventId>(),
+                    It.IsAny<FormattedLogValues>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<object, Exception, string>>()),
+                Times.Once, $"Could not find standard with StandardReference: { standardReference } and Version: { version}");
+
+            Assert.AreEqual(null, result);
+        }
+
+        [Test, AutoData]
+        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_UseStandardUIdToCallOuterApi(string standardReference, decimal version, Standard getStandardResponse, GetStandardByIdResponse getStandardByIdResponse)
+        {
+            _mockStandardRepository.Setup(repository => repository.GetStandardByStandardReferenceAndVersion(standardReference, version))
+                .ReturnsAsync(getStandardResponse);
+
+            _mockOuterApiClient.Setup(client => client.Get<GetStandardByIdResponse>(It.Is<GetStandardByIdRequest>(x => x.Id == getStandardResponse.StandardUId)))
+                .ReturnsAsync(getStandardByIdResponse);
+
+            var result = await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+
+            Assert.IsInstanceOf<StandardOptions>(result);
+            _mockOuterApiClient.Verify(client => client.Get<GetStandardByIdResponse>(It.Is<GetStandardByIdRequest>(x => x.Id == getStandardResponse.StandardUId)), Times.Once);
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
@@ -99,7 +99,7 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
         }
 
         [Test, AutoData]
-        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_StandardIsRetrievedFromAssessorStandardsTable(string standardReference, decimal version, Standard getStandardResponse)
+        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_StandardIsRetrievedFromAssessorStandardsTable(string standardReference, string version, Standard getStandardResponse)
         {
             _mockStandardRepository.Setup(repository => repository.GetStandardByStandardReferenceAndVersion(standardReference, version))
                 .ReturnsAsync(getStandardResponse);
@@ -110,9 +110,9 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
         }
 
         [Test, AutoData]
-        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_And_StandardWithReferenceAndVersionIsNotFound_Then_LogError_And_ReturnNull(string standardReference, decimal version)
+        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_And_StandardWithReferenceAndVersionIsNotFound_Then_LogError_And_ReturnNull(string standardReference, string version)
         {
-            _mockStandardRepository.Setup(repository => repository.GetStandardByStandardReferenceAndVersion(It.IsAny<string>(), It.IsAny<decimal>()))
+            _mockStandardRepository.Setup(repository => repository.GetStandardByStandardReferenceAndVersion(It.IsAny<string>(), It.IsAny<string>()))
                 .Throws(new Exception());
 
             var result = await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
@@ -127,7 +127,7 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
         }
 
         [Test, AutoData]
-        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_UseStandardUIdToCallOuterApi(string standardReference, decimal version, Standard getStandardResponse, GetStandardByIdResponse getStandardByIdResponse)
+        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_UseStandardUIdToCallOuterApi(string standardReference, string version, Standard getStandardResponse, GetStandardByIdResponse getStandardByIdResponse)
         {
             _mockStandardRepository.Setup(repository => repository.GetStandardByStandardReferenceAndVersion(standardReference, version))
                 .ReturnsAsync(getStandardResponse);

--- a/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardServiceController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardServiceController.cs
@@ -69,5 +69,16 @@ namespace SFA.DAS.AssessorService.Application.Api.Controllers
             var standardOptions = await _standardService.GetStandardOptionsByStandardId(id);
             return Ok(standardOptions);
         }
+
+        [HttpGet("standard-options/{standardReference}/{version}", Name = "GetStandardOptionsByStandardReferenceAndVersion")]
+        [SwaggerResponse((int)HttpStatusCode.OK, Type = typeof(StandardOptions))]
+        [SwaggerResponse((int)HttpStatusCode.BadRequest, Type = typeof(IDictionary<string, string>))]
+        [SwaggerResponse((int)HttpStatusCode.InternalServerError, Type = typeof(ApiResponse))]
+        public async Task<IActionResult> GetStandardOptionsForStandardReferenceAndVersion(string standardReference, decimal version)
+        {
+            _logger.LogInformation($"Get standard options from Standard Service for standard with standard reference {standardReference} and verion {version}");
+            var standardOptions = await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+            return Ok(standardOptions);
+        }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardServiceController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardServiceController.cs
@@ -74,7 +74,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Controllers
         [SwaggerResponse((int)HttpStatusCode.OK, Type = typeof(StandardOptions))]
         [SwaggerResponse((int)HttpStatusCode.BadRequest, Type = typeof(IDictionary<string, string>))]
         [SwaggerResponse((int)HttpStatusCode.InternalServerError, Type = typeof(ApiResponse))]
-        public async Task<IActionResult> GetStandardOptionsForStandardReferenceAndVersion(string standardReference, decimal version)
+        public async Task<IActionResult> GetStandardOptionsForStandardReferenceAndVersion(string standardReference, string version)
         {
             _logger.LogInformation($"Get standard options from Standard Service for standard with standard reference {standardReference} and verion {version}");
             var standardOptions = await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);

--- a/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
@@ -117,6 +117,24 @@ namespace SFA.DAS.AssessorService.Application.Api.Services
             return null;
         }
 
+        public async Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, decimal version)
+        {
+            Standard standard;
+
+            try
+            {
+                standard = await _standardRepository.GetStandardByStandardReferenceAndVersion(standardReference, version);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Could not find standard with StandardReference: {standardReference} and Version: {version}");
+
+                return null;
+            }
+
+            return await GetStandardOptionsByStandardId(standard.StandardUId);
+        }
+
         public async Task<IEnumerable<EPORegisteredStandards>> GetEpaoRegisteredStandards(string endPointAssessorOrganisationId)
         {
             var results = await _standardRepository.GetEpaoRegisteredStandards(endPointAssessorOrganisationId, int.MaxValue, 1);

--- a/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
@@ -117,7 +117,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Services
             return null;
         }
 
-        public async Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, decimal version)
+        public async Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version)
         {
             Standard standard;
 

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardRepository.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardRepository.cs
@@ -13,6 +13,7 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
         Task<List<StandardCollation>> GetStandardCollations();
         Task<StandardCollation> GetStandardCollationByStandardId(int standardId);
         Task<StandardCollation> GetStandardCollationByReferenceNumber(string referenceNumber);
+        Task<Standard> GetStandardByStandardReferenceAndVersion(string standardReference, decimal version);
 
         Task<List<StandardNonApprovedCollation>> GetStandardNonApprovedCollations();
         Task<StandardNonApprovedCollation> GetStandardNonApprovedCollationByReferenceNumber(string referenceNumber);

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardRepository.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardRepository.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
         Task<List<StandardCollation>> GetStandardCollations();
         Task<StandardCollation> GetStandardCollationByStandardId(int standardId);
         Task<StandardCollation> GetStandardCollationByReferenceNumber(string referenceNumber);
-        Task<Standard> GetStandardByStandardReferenceAndVersion(string standardReference, decimal version);
+        Task<Standard> GetStandardByStandardReferenceAndVersion(string standardReference, string version);
 
         Task<List<StandardNonApprovedCollation>> GetStandardNonApprovedCollations();
         Task<StandardNonApprovedCollation> GetStandardNonApprovedCollationByReferenceNumber(string referenceNumber);

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardService.cs
@@ -16,5 +16,6 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
         
         Task<IEnumerable<StandardOptions>> GetStandardOptions();
         Task<StandardOptions> GetStandardOptionsByStandardId(string id);
+        Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, decimal version);
     }
 }

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardService.cs
@@ -16,6 +16,6 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
         
         Task<IEnumerable<StandardOptions>> GetStandardOptions();
         Task<StandardOptions> GetStandardOptionsByStandardId(string id);
-        Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, decimal version);
+        Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version);
     }
 }

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/Handlers/StandardsHandler.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/Handlers/StandardsHandler.cs
@@ -1,0 +1,57 @@
+﻿using SFA.DAS.AssessorService.Data.IntegrationTests.Models;
+using SFA.DAS.AssessorService.Data.IntegrationTests.Services;
+using System.Collections.Generic;
+
+namespace SFA.DAS.AssessorService.Data.IntegrationTests.Handlers
+{
+    public class StandardsHandler
+    {
+        private static readonly DatabaseService DatabaseService = new DatabaseService();
+
+        public static void InsertRecord(StandardModel standard)
+        {
+            var sqlToInsertStandard =
+                "INSERT INTO [dbo].[Standards]" +
+                    "([StandardUId]" +
+                    ", [IFateReferenceNumber]" +
+                    ", [Version]" +
+                    ", [Title]" +
+                    ", [Level]" +
+                    ", [Status]" +
+                    ", [TypicalDuration]" +
+                    ", [MaxFunding]" +
+                    ", [IsActive]" +
+                    ", [ProposedTypicalDuration]" +
+                    ", [ProposedMaxFunding])" +
+                "VALUES " +
+                    "(@StandardUId" +
+                    ", @iFateReferenceNumber" +
+                    ", @version" +
+                    ", @title" +
+                    ", @level" +
+                    ", @status" +
+                    ", @typicalDuration" +
+                    ", @maxFunding" +
+                    ", @isActive" +
+                    ", @proposedTypicalDuration" +
+                    ", @proposedMaxFunding)";
+
+            DatabaseService.Execute(sqlToInsertStandard, standard);
+        }
+
+        public static void InsertRecords(List<StandardModel> standards)
+        {
+            foreach (var standard in standards)
+            {
+                InsertRecord(standard);
+            }
+        }
+
+        public static void DeleteAllRecords()
+        {
+            var sql = "DELETE FROM [Standards]";
+
+            DatabaseService.Execute(sql);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/Models/StandardModel.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/Models/StandardModel.cs
@@ -1,0 +1,18 @@
+﻿
+namespace SFA.DAS.AssessorService.Data.IntegrationTests.Models
+{
+    public class StandardModel : TestModel
+    {
+        public string StandardUId { get; set; }
+        public string IFateReferenceNumber { get; set; }
+        public decimal Version { get; set; }
+        public int Level { get; set; }
+        public string Title { get; set; }
+        public string Status { get; set; }
+        public int TypicalDuration { get; set; }
+        public int MaxFunding { get; set; }
+        public int IsActive { get; set; }
+        public int ProposedTypicalDuration { get; set; }
+        public int ProposedMaxFunding { get; set; }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/StandardsGetTests.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/StandardsGetTests.cs
@@ -1,0 +1,138 @@
+﻿using NUnit.Framework;
+using SFA.DAS.AssessorService.Data.IntegrationTests.Handlers;
+using SFA.DAS.AssessorService.Data.IntegrationTests.Models;
+using SFA.DAS.AssessorService.Data.IntegrationTests.Services;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Data.IntegrationTests
+{
+    [TestFixture]
+    public class StandardsGetTests : TestBase
+    {
+        private readonly DatabaseService _databaseService = new DatabaseService();
+
+        private SqlConnection _databaseConnection;
+        private UnitOfWork _unitOfWork;
+        private StandardRepository _repository;
+
+        private List<StandardModel> _standards;
+
+        [OneTimeSetUp]
+        public void SetupStandardsTable()
+        {
+            _databaseConnection = new SqlConnection(_databaseService.WebConfiguration.SqlConnectionString);
+            _unitOfWork = new UnitOfWork(_databaseConnection);
+            _repository = new StandardRepository(_unitOfWork);
+            
+            _standards = GetListOfStandardVersions();
+
+            StandardsHandler.InsertRecords(_standards);
+        }
+
+        [TestCase("ST0001", "1", "ST0001_1.0")]
+        [TestCase("ST0001", "1.0", "ST0001_1.0")]
+        [TestCase("ST0001", "1.00", "ST0001_1.0")]
+        [TestCase("ST0001", "1.1", "ST0001_1.1")]
+        [TestCase("ST0001", "1.2", "ST0001_1.2")]
+        [TestCase("ST0001", "1.10", "ST0001_1.10", Ignore = "Test will fail until version is stored as string (SV-568)")]
+        [TestCase("ST0001", "1.12", "ST0001_1.12", Ignore = "Test will fail until version is stored as string (SV-568)")]
+        public async Task GetStandardByStandardReferenceAndVersion_ReturnsCorrectStandard(string standardReference, string version, string standardUId)
+        {
+            var expectedStandard = _standards.Single(s => s.StandardUId == standardUId);
+
+            var standard = await _repository.GetStandardByStandardReferenceAndVersion(standardReference, version);
+
+            Assert.AreEqual(expectedStandard.StandardUId, standard.StandardUId);
+        }
+
+        [OneTimeTearDown]
+        public void TearDownStandardsTable()
+        {
+            StandardsHandler.DeleteAllRecords();
+
+            if (_databaseConnection != null)
+            {
+                _databaseConnection.Dispose();
+            }
+        }
+
+        private List<StandardModel> GetListOfStandardVersions()
+        {
+            return new List<StandardModel>{
+                new StandardModel
+                {
+                    StandardUId = "ST0001_1.0",
+                    IFateReferenceNumber = "ST0001",
+                    Version = 1.0m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                },
+                new StandardModel
+                {
+                    StandardUId = "ST0001_1.1",
+                    IFateReferenceNumber = "ST0001",
+                    Version = 1.1m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                },
+                 new StandardModel
+                {
+                    StandardUId = "ST0001_1.2",
+                    IFateReferenceNumber = "ST0001",
+                    Version = 1.2m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                },
+                new StandardModel
+                {
+                    StandardUId = "ST0001_1.10",
+                    IFateReferenceNumber = "ST0001",
+                    Version = 1.10m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                },
+                new StandardModel
+                {
+                    StandardUId = "ST0001_1.12",
+                    IFateReferenceNumber = "ST0001",
+                    Version = 1.12m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                }
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Data/StandardRepository.cs
+++ b/src/SFA.DAS.AssessorService.Data/StandardRepository.cs
@@ -84,23 +84,21 @@ namespace SFA.DAS.AssessorService.Data
             return standards.FirstOrDefault();
         }
 
-        public async Task<Standard> GetStandardByStandardReferenceAndVersion(string standardReference, decimal version)
+        public async Task<Standard> GetStandardByStandardReferenceAndVersion(string standardReference, string version)
         {
-            var standards = await GetStandardsByStandardReferenceInternal(standardReference);
-
-            return standards.Single(standard => standard.Version == version);
+            return await GetStandardsByStandardReferenceAndVersionInternal(standardReference, version);
         }
 
-        private async Task<List<Standard>> GetStandardsByStandardReferenceInternal(string standardReference)
+        private async Task<Standard> GetStandardsByStandardReferenceAndVersionInternal(string standardReference, string version)
         {
-            var sql = "SELECT * FROM [Standards] WHERE IFateReferenceNumber = @standardReference";
+            var sql = "SELECT * FROM [Standards] WHERE IFateReferenceNumber = @standardReference AND Version = @version";
 
             var results = await _unitOfWork.Connection.QueryAsync<Standard>(
                 sql,
-                param: new { standardReference},
+                param: new { standardReference, version},
                 transaction: _unitOfWork.Transaction);
 
-            return results.ToList();
+            return results.FirstOrDefault();
         }
 
         public async Task<List<Option>> GetOptions(int stdCode)

--- a/src/SFA.DAS.AssessorService.Data/StandardRepository.cs
+++ b/src/SFA.DAS.AssessorService.Data/StandardRepository.cs
@@ -84,6 +84,25 @@ namespace SFA.DAS.AssessorService.Data
             return standards.FirstOrDefault();
         }
 
+        public async Task<Standard> GetStandardByStandardReferenceAndVersion(string standardReference, decimal version)
+        {
+            var standards = await GetStandardsByStandardReferenceInternal(standardReference);
+
+            return standards.Single(standard => standard.Version == version);
+        }
+
+        private async Task<List<Standard>> GetStandardsByStandardReferenceInternal(string standardReference)
+        {
+            var sql = "SELECT * FROM [Standards] WHERE IFateReferenceNumber = @standardReference";
+
+            var results = await _unitOfWork.Connection.QueryAsync<Standard>(
+                sql,
+                param: new { standardReference},
+                transaction: _unitOfWork.Transaction);
+
+            return results.ToList();
+        }
+
         public async Task<List<Option>> GetOptions(int stdCode)
         {
             return await GetOptionsInternal(new List<int> { stdCode }, true);

--- a/src/SFA.DAS.AssessorService.sln
+++ b/src/SFA.DAS.AssessorService.sln
@@ -58,6 +58,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.AssessorService.Ses
 EndProject
 Project("{00D1A9C2-B5F0-4AF3-8072-F6C62B433612}") = "SFA.DAS.AssessorService.Database", "SFA.DAS.AssessorService.Database\SFA.DAS.AssessorService.Database.sqlproj", "{BA3B0BA5-07CB-4BCF-A504-96127F500A39}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.AssessorService.Application.Api.External.UnitTests", "SFA.DAS.AssessorService.Application.Api.External.UnitTests\SFA.DAS.AssessorService.Application.Api.External.UnitTests.csproj", "{5319DB03-A39B-49EC-B375-A8957E21C1D6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -137,6 +139,10 @@ Global
 		{BA3B0BA5-07CB-4BCF-A504-96127F500A39}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA3B0BA5-07CB-4BCF-A504-96127F500A39}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BA3B0BA5-07CB-4BCF-A504-96127F500A39}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{5319DB03-A39B-49EC-B375-A8957E21C1D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5319DB03-A39B-49EC-B375-A8957E21C1D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5319DB03-A39B-49EC-B375-A8957E21C1D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5319DB03-A39B-49EC-B375-A8957E21C1D6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,6 +154,7 @@ Global
 		{3B16AB0E-5C83-4E5D-82B0-7021AB4C5B9F} = {F85262CD-4210-4352-B691-30F40D99B4D2}
 		{C6966220-9CF5-41CA-92CD-DF428AD66AB5} = {EB54D000-867F-48CA-AE28-BDBE0CCE1322}
 		{69B3D223-F8CA-4AF9-A258-F5DF1AE24F27} = {EB54D000-867F-48CA-AE28-BDBE0CCE1322}
+		{5319DB03-A39B-49EC-B375-A8957E21C1D6} = {EB54D000-867F-48CA-AE28-BDBE0CCE1322}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C5B677B2-0D72-4629-A5FD-F94B00EC858B}


### PR DESCRIPTION
I've created the get standard version endpoint and added a unit test project for the external API.

To get the StandardUId I have found all standards with the given standard reference and then tried to match with the given version. I thought this was better than querying based on the standard reference and version as the original query could be reused or it might help if we need error handling that says "version x does not exist for that standard".

Once we know the StandardUId I could use the existing outer API method 