### PR TITLE
SV-607 Fail Date Not Being Pre-Populated

### DIFF
--- a/src/SFA.DAS.AssessorService.Web/ViewModels/Certificate/CertificateDateViewModel.cs
+++ b/src/SFA.DAS.AssessorService.Web/ViewModels/Certificate/CertificateDateViewModel.cs
@@ -19,12 +19,10 @@ namespace SFA.DAS.AssessorService.Web.ViewModels.Certificate
         {
             base.FromCertificate(cert);
 
-            if (CertificateData.OverallGrade != CertificateGrade.Fail)
-            {
-                Day = CertificateData.AchievementDate?.Day.ToString();
-                Month = CertificateData.AchievementDate?.Month.ToString();
-                Year = CertificateData.AchievementDate?.Year.ToString();
-            }
+            Day = CertificateData.AchievementDate?.Day.ToString();
+            Month = CertificateData.AchievementDate?.Month.ToString();
+            Year = CertificateData.AchievementDate?.Year.ToString();
+            
             StartDate = CertificateData.LearningStartDate;
             SelectedGrade = CertificateData.OverallGrade;
             WarningShown = "false";

--- a/src/SFA.DAS.AssessorService.Web/Views/Certificate/Date.cshtml
+++ b/src/SFA.DAS.AssessorService.Web/Views/Certificate/Date.cshtml
@@ -114,19 +114,6 @@ else
 
                 <button type="submit" class="govuk-button">@Localizer["ContinueButton"]</button>
 
-                @*
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary">
-                        <span class="govuk-details__summary-text">
-                            @Localizer["InfoHeader"]
-                        </span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        @Localizer["InfoBody"]
-                    </div>
-                </details>
-                *@
-
             </form>
         </div>
     </div>


### PR DESCRIPTION
Resolves issue with Certificate Date Model so that the fail date is shown on the date page.
Resolves bug with options whereby you can't change version and redirect back to check without having set an option.
( can still press back but this will be resolved via submit check page validation )