### PR TITLE
SV-635 Patch for "version" data field in CertificateData

### DIFF
--- a/src/SFA.DAS.AssessorService.Database/PostDeploymentScripts/EPAO_Migration_Part0_Patch.sql
+++ b/src/SFA.DAS.AssessorService.Database/PostDeploymentScripts/EPAO_Migration_Part0_Patch.sql
@@ -1,0 +1,13 @@
+﻿/*
+patch Certificates.CertificateData "version" to "Version"					
+*/
+
+UPDATE  Certificates
+SET CertificateData =
+CASE WHEN  JSON_VALUE(CertificateData,'$.Version')  IS NULL
+THEN JSON_MODIFY(JSON_MODIFY(CertificateData,'$.version', null),'$.Version','')
+ELSE JSON_MODIFY(CertificateData,'$.version', null)
+END
+where JSON_VALUE(CertificateData,'$.version')  = '' 
+and StandardUId IS NOT NULL
+

--- a/src/SFA.DAS.AssessorService.Database/SFA.DAS.AssessorService.Database.sqlproj
+++ b/src/SFA.DAS.AssessorService.Database/SFA.DAS.AssessorService.Database.sqlproj
@@ -157,6 +157,7 @@
     <Build Include="StoredProcedures\DatabaseMaintenance.sql" />
     <Build Include="Security\Roles\DatabaseRoles\DatabaseMaintenance.sql" />
     <None Include="PostDeploymentScripts\GrantOrDenyPermissions.sql" />
+    <None Include="PostDeploymentScripts\EPAO_Migration_Part0_Patch.sql" />
     <None Include="PostDeploymentScripts\EPAO_Migration_Part1_Certificates.sql" />
     <None Include="PostDeploymentScripts\EPAO_Migration_Part2_OrganisationStandard.sql" />
     <None Include="PostDeploymentScripts\EPAO_Migration_Part3_OrganisationStandardVersion.sql" />


### PR DESCRIPTION
This fixes the use of "Version":"" rather than "version":"" in CertificateData for the histocial certificate records. 