### PR TITLE
SV-511 allow resuming when recording a retake after fail

### DIFF
--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Certificates/StartCertificateHandlerTests/When_called_and_certificate_previously_recorded_a_fail.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/Certificates/StartCertificateHandlerTests/When_called_and_certificate_previously_recorded_a_fail.cs
@@ -1,0 +1,84 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models.Certificates;
+using SFA.DAS.AssessorService.Application.Handlers.Staff;
+using SFA.DAS.AssessorService.Application.Infrastructure;
+using SFA.DAS.AssessorService.Application.Interfaces;
+using SFA.DAS.AssessorService.Domain.Consts;
+using SFA.DAS.AssessorService.Domain.Entities;
+using SFA.DAS.AssessorService.Domain.JsonData;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.Certificates.StartCertificateHandlerTests
+{
+    [TestFixture]
+    public class When_called_and_certificate_previously_recorded_a_fail
+    {
+        private Mock<ICertificateRepository> _certificateRepository;
+
+        private StartCertificateHandler _startCertificateHandler;
+
+        private StartCertificateRequest _request;
+
+        private const int _standardCode = 1;
+        private const long _uln = 1000000000;
+
+        [SetUp]
+        public void Arrange()
+        {
+            var certificateData = new Builder().CreateNew<CertificateData>()
+                .With(cd => cd.OverallGrade = CertificateGrade.Fail)
+                .Build();
+
+            var certDataString = JsonConvert.SerializeObject(certificateData);
+
+            var certificate = new Builder().CreateNew<Certificate>()
+                .With(c => c.Uln = _uln)
+                .With(c => c.StandardCode = _standardCode)
+                .With(c => c.Status = CertificateStatus.Submitted)
+                .With(c => c.CertificateData = certDataString)
+                .Build();
+
+            _certificateRepository = new Mock<ICertificateRepository>();
+
+            _certificateRepository.Setup(r => r.GetCertificate(_uln, _standardCode))
+                .ReturnsAsync(certificate);
+
+            _request = new StartCertificateRequest
+            {
+                Uln = _uln,
+                StandardCode = _standardCode
+            };
+
+            _startCertificateHandler = new StartCertificateHandler(_certificateRepository.Object,
+                Mock.Of<IIlrRepository>(), 
+                Mock.Of<IRoatpApiClient>(),
+                Mock.Of<IOrganisationQueryRepository>(), 
+                Mock.Of<ILogger<StartCertificateHandler>>(), 
+                Mock.Of<IStandardService>());
+        }
+
+        [Test]
+        public async Task Then_set_status_to_draft_and_call_update_certificate()
+        {
+            await _startCertificateHandler.Handle(_request, new CancellationToken());
+
+            _certificateRepository.Verify(r => r.Update(It.Is<Certificate>(c => c.Status == CertificateStatus.Draft && c.Uln == _uln && c.StandardCode == _standardCode),
+                It.IsAny<string>(), CertificateActions.StartRetake, true, "Retake failed apprenticeship"), Times.Once);
+        }
+
+        [Test]
+        public async Task Then_certificate_is_return_with_status_set_to_draft()
+        {
+            var cert = await _startCertificateHandler.Handle(_request, new CancellationToken());
+
+            cert.Status.Should().Be(CertificateStatus.Draft);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application/Handlers/Staff/StartCertificateHandler.cs
+++ b/src/SFA.DAS.AssessorService.Application/Handlers/Staff/StartCertificateHandler.cs
@@ -66,7 +66,7 @@ namespace SFA.DAS.AssessorService.Application.Handlers.Staff
                         await _certificateRepository.Update(certificate, request.Username, null);
                     }
                 }
-                else if (certData.OverallGrade == CertificateGrade.Fail)
+                else if (certificate.Status == CertificateStatus.Submitted && certData.OverallGrade == CertificateGrade.Fail)
                 {
                     _logger.LogInformation($"Starting retake of apprenticeship for ULN: {certificate.Uln}, Standard: {certificate.StandardCode}");
 

--- a/src/SFA.DAS.AssessorService.Domain/Consts/CertificateActions.cs
+++ b/src/SFA.DAS.AssessorService.Domain/Consts/CertificateActions.cs
@@ -3,6 +3,7 @@
     public static class CertificateActions
     {
         public const string Start = "Start";
+        public const string StartRetake = "StartRetake";
         public const string Address = "Address";
         public const string AddressSummary = "AddressSummary";
         public const string Date = "Date";


### PR DESCRIPTION
We were previously unable to leave and resume recording a pass from a previously failed apprenticeship as when Starting the new certificate if a failed certificate was found it would be returned and we were allowed to overwrite it. However, the status of the certificate was still Submitted, so when we changed the grade to a pass and left the search found a passing, submitted certificate and did not allow changes to be made.

I have added a check when starting a new certificate so that if the result is Submitted + Fail then set status to draft and log that it is recording a retake. Submitted is important so draft fails aren't logged as retakes.

