### PR TITLE
SV-619 validate all fields on check page on submit

### DIFF
--- a/src/SFA.DAS.AssessorService.Web.UnitTests/Validators/CertificateCheckViewModelValidatorTests.cs
+++ b/src/SFA.DAS.AssessorService.Web.UnitTests/Validators/CertificateCheckViewModelValidatorTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using SFA.DAS.AssessorService.Domain.Consts;
 using SFA.DAS.AssessorService.Web.Validators;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
-
+using System.Linq;
 
 namespace SFA.DAS.AssessorService.Web.UnitTests.Validators
 {
@@ -18,6 +18,8 @@ namespace SFA.DAS.AssessorService.Web.UnitTests.Validators
         private const string _optionError = "Option error message";
         private const string _gradeError = "Grade error message";
         private const string _dateError = "Date error message";
+        private const string _passDateError = "Pass date error message";
+        private const string _failDateError = "Fail date error message";
         private const string _postcodeError = "Postcode error message";
         private const string _cityError = "City error message";
         private const string _addressLine1Error = "Postcode error message";
@@ -37,7 +39,9 @@ namespace SFA.DAS.AssessorService.Web.UnitTests.Validators
             _mockStringLocalizer.Setup(l => l["VersionCannotBeNull"]).Returns(new LocalizedString("Version", _versionError));
             _mockStringLocalizer.Setup(l => l["OptionCannotBeNull"]).Returns(new LocalizedString("Option", _optionError));
             _mockStringLocalizer.Setup(l => l["GradeCannotBeNull"]).Returns(new LocalizedString("Option", _gradeError));
-            _mockStringLocalizer.Setup(l => l["AchievementDateCannotBeEmpty"]).Returns(new LocalizedString("Date", _dateError));
+            _mockStringLocalizer.Setup(l => l["DateCannotBeEmpty"]).Returns(new LocalizedString("Date", _dateError));
+            _mockStringLocalizer.Setup(l => l["AchievementDateCannotBeEmpty"]).Returns(new LocalizedString("Date", _passDateError));
+            _mockStringLocalizer.Setup(l => l["FailDateCannotBeEmpty"]).Returns(new LocalizedString("Date", _failDateError));
             _mockStringLocalizer.Setup(l => l["PostcodeCannotBeEmpty"]).Returns(new LocalizedString("Postcode", _postcodeError));
             _mockStringLocalizer.Setup(l => l["CityCannotBeEmpty"]).Returns(new LocalizedString("City", _cityError));
             _mockStringLocalizer.Setup(l => l["AddressLine1CannotBeEmpty"]).Returns(new LocalizedString("Address", _addressLine1Error));
@@ -78,6 +82,43 @@ namespace SFA.DAS.AssessorService.Web.UnitTests.Validators
             _viewModel.AchievementDate = null;
 
             _validator.ShouldHaveValidationErrorFor(vm => vm.AchievementDate, _viewModel);
+        }
+
+        [Test]
+        public void When_OverallGradeIsNull_And_AchievementDateIsNull_Then_ValidatorReturnsInvalid_WithGenericErrorMessage()
+        {
+            _viewModel.SelectedGrade = null;
+            _viewModel.AchievementDate = null;
+
+            var result = _validator.Validate(_viewModel);
+
+            result.Errors.FirstOrDefault(error => error.PropertyName == "AchievementDate").ErrorMessage.Should().Be(_dateError);
+        }
+
+        [Test]
+        public void When_OverallGradeIsFail_And_AchievementDateIsNull_Then_ValidatorReturnsInvalid_WithFailErrorMessage()
+        {
+            _viewModel.SelectedGrade = CertificateGrade.Fail;
+            _viewModel.AchievementDate = null;
+
+            var result = _validator.Validate(_viewModel);
+
+            result.Errors.Single().ErrorMessage.Should().Be(_failDateError);
+        }
+
+        [TestCase(CertificateGrade.Pass)]
+        [TestCase(CertificateGrade.PassWithExcellence)]
+        [TestCase(CertificateGrade.Merit)]
+        [TestCase(CertificateGrade.Outstanding)]
+        [TestCase(CertificateGrade.Distinction)]
+        public void When_OverallGradeIsNotFail_And_AchievementDateIsNull_Then_ValidatorReturnsInvalid_WithGenericErrorMessage(string certificateGrade)
+        {
+            _viewModel.SelectedGrade = certificateGrade;
+            _viewModel.AchievementDate = null;
+
+            var result = _validator.Validate(_viewModel);
+
+            result.Errors.Single().ErrorMessage.Should().Be(_passDateError);
         }
 
         [Test]

--- a/src/SFA.DAS.AssessorService.Web.UnitTests/Validators/CertificateCheckViewModelValidatorTests.cs
+++ b/src/SFA.DAS.AssessorService.Web.UnitTests/Validators/CertificateCheckViewModelValidatorTests.cs
@@ -1,0 +1,142 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using FluentValidation.Results;
+using FluentValidation.TestHelper;
+using Microsoft.Extensions.Localization;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Domain.Consts;
+using SFA.DAS.AssessorService.Web.Validators;
+using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
+
+
+namespace SFA.DAS.AssessorService.Web.UnitTests.Validators
+{
+    public class CertificateCheckViewModelValidatorTests
+    {
+        private const string _versionError = "Version error message";
+        private const string _optionError = "Option error message";
+        private const string _gradeError = "Grade error message";
+        private const string _dateError = "Date error message";
+        private const string _postcodeError = "Postcode error message";
+        private const string _cityError = "City error message";
+        private const string _addressLine1Error = "Postcode error message";
+        private const string _nameError = "Name error message"; 
+
+        private Mock<IStringLocalizer<CertificateCheckViewModelValidator>> _mockStringLocalizer;
+
+        private CertificateCheckViewModel _viewModel;
+
+        private CertificateCheckViewModelValidator _validator;
+
+        [SetUp]
+        public void Arange()
+        {
+            _mockStringLocalizer = new Mock<IStringLocalizer<CertificateCheckViewModelValidator>>();
+
+            _mockStringLocalizer.Setup(l => l["VersionCannotBeNull"]).Returns(new LocalizedString("Version", _versionError));
+            _mockStringLocalizer.Setup(l => l["OptionCannotBeNull"]).Returns(new LocalizedString("Option", _optionError));
+            _mockStringLocalizer.Setup(l => l["GradeCannotBeNull"]).Returns(new LocalizedString("Option", _gradeError));
+            _mockStringLocalizer.Setup(l => l["AchievementDateCannotBeEmpty"]).Returns(new LocalizedString("Date", _dateError));
+            _mockStringLocalizer.Setup(l => l["PostcodeCannotBeEmpty"]).Returns(new LocalizedString("Postcode", _postcodeError));
+            _mockStringLocalizer.Setup(l => l["CityCannotBeEmpty"]).Returns(new LocalizedString("City", _cityError));
+            _mockStringLocalizer.Setup(l => l["AddressLine1CannotBeEmpty"]).Returns(new LocalizedString("Address", _addressLine1Error));
+            _mockStringLocalizer.Setup(l => l["NameCannotBeEmpty"]).Returns(new LocalizedString("Name", _nameError));
+            
+            _viewModel = CreateValidViewModel();
+
+            _validator = new CertificateCheckViewModelValidator(_mockStringLocalizer.Object);
+        }
+
+        [Test]
+        public void When_AllFieldsAreCorrect_Then_ValidatorReturnsValid()
+        {
+            var result = _validator.Validate(_viewModel);
+
+            result.IsValid.Should().Be(true);       
+        }
+
+        [Test]
+        public void When_VersionIsNull_Then_ValidatorReturnsInvalid()
+        {
+            _viewModel.Version = null;
+
+            _validator.ShouldHaveValidationErrorFor(vm => vm.Version, _viewModel);
+        }
+
+        [Test]
+        public void When_GradeIsNull_Then_ValidatorReturnsInvalid()
+        {
+            _viewModel.SelectedGrade = null;
+
+            _validator.ShouldHaveValidationErrorFor(vm => vm.SelectedGrade, _viewModel);
+        }
+
+        [Test]
+        public void When_AchievementDateIsNull_Then_ValidatorReturnsInvalid()
+        {
+            _viewModel.AchievementDate = null;
+
+            _validator.ShouldHaveValidationErrorFor(vm => vm.AchievementDate, _viewModel);
+        }
+
+        [Test]
+        public void When_StandardHasNoOptions_And_OptionIsNull_Then_ValidatorReturnsValid()
+        {
+            _viewModel.StandardHasOptions = false;
+            _viewModel.Option = null;
+
+            var result = _validator.Validate(_viewModel);
+
+            result.IsValid.Should().Be(true);
+        }
+
+        [Test]
+        public void When_StandardHasOptions_And_OptionIsNull_Then_ValidatorReturnInvalid()
+        {
+            _viewModel.StandardHasOptions = true;
+            _viewModel.Option = null;
+
+            _validator.ShouldHaveValidationErrorFor(vm => vm.Option, _viewModel);
+        }
+
+        [Test]
+        public void When_SelectedGradeIsFail_And_AddressInformationIsNotGiven_Then_ValidatorReturnsValid()
+        {
+            _viewModel.SelectedGrade = CertificateGrade.Fail;
+            _viewModel.Name = null;
+            _viewModel.AddressLine1 = null;
+            _viewModel.City = null;
+            _viewModel.Postcode = null;
+
+            var result = _validator.Validate(_viewModel);
+            
+            result.IsValid.Should().Be(true);
+        }
+
+        [TestCase(CertificateGrade.Pass)]
+        [TestCase(CertificateGrade.PassWithExcellence)]
+        [TestCase(CertificateGrade.Merit)]
+        [TestCase(CertificateGrade.Outstanding)]
+        [TestCase(CertificateGrade.Distinction)]
+        public void When_SelectedGradeIsPass_And_AddressInformationIsNotGiven_Then_ValidatorReturnsInvalid(string certificateGrade)
+        {
+            _viewModel.SelectedGrade = certificateGrade;
+            _viewModel.Name = null;
+            _viewModel.AddressLine1 = null;
+            _viewModel.City = null;
+            _viewModel.Postcode = null;
+
+            _validator.ShouldHaveValidationErrorFor(vm => vm.Name, _viewModel);
+            _validator.ShouldHaveValidationErrorFor(vm => vm.AddressLine1, _viewModel);
+            _validator.ShouldHaveValidationErrorFor(vm => vm.City, _viewModel);
+            _validator.ShouldHaveValidationErrorFor(vm => vm.Postcode, _viewModel);
+        }
+
+        private CertificateCheckViewModel CreateValidViewModel()
+        {
+            return new Builder().CreateNew<CertificateCheckViewModel>()
+                .Build();
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Web/Controllers/CertificateCheckController.cs
+++ b/src/SFA.DAS.AssessorService.Web/Controllers/CertificateCheckController.cs
@@ -1,12 +1,11 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using SFA.DAS.AssessorService.Application.Api.Client.Clients;
 using SFA.DAS.AssessorService.Domain.Consts;
 using SFA.DAS.AssessorService.Web.Infrastructure;
-using SFA.DAS.AssessorService.Web.Validators;
 using SFA.DAS.AssessorService.Web.ViewModels.Certificate;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,10 +16,10 @@ namespace SFA.DAS.AssessorService.Web.Controllers
     [Route("certificate/check")]
     public class CertificateCheckController : CertificateBaseController
     {
-        private readonly CertificateCheckViewModelValidator _validator;
+        private readonly IValidator<CertificateCheckViewModel> _validator;
 
         public CertificateCheckController(ILogger<CertificateController> logger, IHttpContextAccessor contextAccessor,
-            ICertificateApiClient certificateApiClient, CertificateCheckViewModelValidator validator, ISessionService sessionService) : base(logger, contextAccessor, certificateApiClient, sessionService)
+            ICertificateApiClient certificateApiClient, IValidator<CertificateCheckViewModel> validator, ISessionService sessionService) : base(logger, contextAccessor, certificateApiClient, sessionService)
         {
             _validator = validator;
         }

--- a/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.Designer.cs
+++ b/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.Designer.cs
@@ -62,6 +62,15 @@ namespace SFA.DAS.AssessorService.Web.Resources.Validators {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enter the achievement date.
+        /// </summary>
+        internal static string AchievementDateCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("AchievementDateCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enter an address.
         /// </summary>
         internal static string AddressLine1CannotBeEmpty {
@@ -76,6 +85,15 @@ namespace SFA.DAS.AssessorService.Web.Resources.Validators {
         internal static string CityCannotBeEmpty {
             get {
                 return ResourceManager.GetString("CityCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select a grade.
+        /// </summary>
+        internal static string GradeCannotBeNull {
+            get {
+                return ResourceManager.GetString("GradeCannotBeNull", resourceCulture);
             }
         }
         
@@ -103,6 +121,15 @@ namespace SFA.DAS.AssessorService.Web.Resources.Validators {
         internal static string SelectAnOption {
             get {
                 return ResourceManager.GetString("SelectAnOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select a version.
+        /// </summary>
+        internal static string VersionCannotBeNull {
+            get {
+                return ResourceManager.GetString("VersionCannotBeNull", resourceCulture);
             }
         }
     }

--- a/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.Designer.cs
+++ b/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.Designer.cs
@@ -89,6 +89,24 @@ namespace SFA.DAS.AssessorService.Web.Resources.Validators {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enter the achievement/fail date.
+        /// </summary>
+        internal static string DateCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("DateCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter the fail date.
+        /// </summary>
+        internal static string FailDateCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("FailDateCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select a grade.
         /// </summary>
         internal static string GradeCannotBeNull {

--- a/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.Designer.cs
+++ b/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.Designer.cs
@@ -107,20 +107,20 @@ namespace SFA.DAS.AssessorService.Web.Resources.Validators {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Select an option.
+        /// </summary>
+        internal static string OptionCannotBeNull {
+            get {
+                return ResourceManager.GetString("OptionCannotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enter a postcode.
         /// </summary>
         internal static string PostcodeCannotBeEmpty {
             get {
                 return ResourceManager.GetString("PostcodeCannotBeEmpty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Select an option.
-        /// </summary>
-        internal static string SelectAnOption {
-            get {
-                return ResourceManager.GetString("SelectAnOption", resourceCulture);
             }
         }
         

--- a/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.resx
+++ b/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.resx
@@ -117,11 +117,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AchievementDateCannotBeEmpty" xml:space="preserve">
+    <value>Enter the achievement date</value>
+  </data>
   <data name="AddressLine1CannotBeEmpty" xml:space="preserve">
     <value>Enter an address</value>
   </data>
   <data name="CityCannotBeEmpty" xml:space="preserve">
     <value>Enter a city or town</value>
+  </data>
+  <data name="GradeCannotBeNull" xml:space="preserve">
+    <value>Select a grade</value>
   </data>
   <data name="NameCannotBeEmpty" xml:space="preserve">
     <value>Enter a name</value>
@@ -131,5 +137,8 @@
   </data>
   <data name="SelectAnOption" xml:space="preserve">
     <value>Select an option</value>
+  </data>
+  <data name="VersionCannotBeNull" xml:space="preserve">
+    <value>Select a version</value>
   </data>
 </root>

--- a/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.resx
+++ b/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.resx
@@ -126,6 +126,12 @@
   <data name="CityCannotBeEmpty" xml:space="preserve">
     <value>Enter a city or town</value>
   </data>
+  <data name="DateCannotBeEmpty" xml:space="preserve">
+    <value>Enter the achievement/fail date</value>
+  </data>
+  <data name="FailDateCannotBeEmpty" xml:space="preserve">
+    <value>Enter the fail date</value>
+  </data>
   <data name="GradeCannotBeNull" xml:space="preserve">
     <value>Select a grade</value>
   </data>

--- a/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.resx
+++ b/src/SFA.DAS.AssessorService.Web/Resources/Validators/CertificateCheckViewModelValidator.resx
@@ -132,11 +132,11 @@
   <data name="NameCannotBeEmpty" xml:space="preserve">
     <value>Enter a name</value>
   </data>
+  <data name="OptionCannotBeNull" xml:space="preserve">
+    <value>Select an option</value>
+  </data>
   <data name="PostcodeCannotBeEmpty" xml:space="preserve">
     <value>Enter a postcode</value>
-  </data>
-  <data name="SelectAnOption" xml:space="preserve">
-    <value>Select an option</value>
   </data>
   <data name="VersionCannotBeNull" xml:space="preserve">
     <value>Select a version</value>

--- a/src/SFA.DAS.AssessorService.Web/Validators/CertificateCheckViewModelValidator.cs
+++ b/src/SFA.DAS.AssessorService.Web/Validators/CertificateCheckViewModelValidator.cs
@@ -21,9 +21,6 @@ namespace SFA.DAS.AssessorService.Web.Validators
             RuleFor(vm => vm.SelectedGrade).NotNull()
                 .WithMessage(localizer["GradeCannotBeNull"]);
 
-            RuleFor(vm => vm.AchievementDate).NotNull()
-                .WithMessage(localizer["AchievementDateCannotBeEmpty"]);
-
             When(vm => vm.SelectedGrade != CertificateGrade.Fail, () =>
             {
                 RuleFor(vm => vm.Postcode).NotEmpty()
@@ -34,6 +31,25 @@ namespace SFA.DAS.AssessorService.Web.Validators
                     .WithMessage(localizer["AddressLine1CannotBeEmpty"]);
                 RuleFor(vm => vm.Name).NotEmpty()
                     .WithMessage(localizer["NameCannotBeEmpty"]);
+                
+                When(vm => vm.SelectedGrade != null, () =>
+                {
+                    RuleFor(vm => vm.AchievementDate).NotNull()
+                       .WithMessage(localizer["AchievementDateCannotBeEmpty"]);
+
+                });
+            });
+
+            When(vm => vm.SelectedGrade == CertificateGrade.Fail, () =>
+            {
+                RuleFor(vm => vm.AchievementDate).NotNull()
+                .WithMessage(localizer["FailDateCannotBeEmpty"]);
+            });
+
+            When(vm => vm.SelectedGrade == null, () =>
+            {
+                RuleFor(vm => vm.AchievementDate).NotNull()
+                .WithMessage(localizer["DateCannotBeEmpty"]);
             });
         }
     }

--- a/src/SFA.DAS.AssessorService.Web/Validators/CertificateCheckViewModelValidator.cs
+++ b/src/SFA.DAS.AssessorService.Web/Validators/CertificateCheckViewModelValidator.cs
@@ -9,6 +9,21 @@ namespace SFA.DAS.AssessorService.Web.Validators
     {
         public CertificateCheckViewModelValidator(IStringLocalizer<CertificateCheckViewModelValidator> localizer)
         {
+            RuleFor(vm => vm.Version).NotNull()
+                .WithMessage(localizer["VersionCannotBeNull"]);
+
+            When(vm => vm.StandardHasOptions, () =>
+            {
+                RuleFor(vm => vm.Option).NotNull()
+                    .WithMessage(localizer["OptionCannotBeNull"]);
+            });
+
+            RuleFor(vm => vm.SelectedGrade).NotNull()
+                .WithMessage(localizer["GradeCannotBeNull"]);
+
+            RuleFor(vm => vm.AchievementDate).NotNull()
+                .WithMessage(localizer["AchievementDateCannotBeEmpty"]);
+
             When(vm => vm.SelectedGrade != CertificateGrade.Fail, () =>
             {
                 RuleFor(vm => vm.Postcode).NotEmpty()
@@ -18,13 +33,7 @@ namespace SFA.DAS.AssessorService.Web.Validators
                 RuleFor(vm => vm.AddressLine1).NotEmpty()
                     .WithMessage(localizer["AddressLine1CannotBeEmpty"]);
                 RuleFor(vm => vm.Name).NotEmpty()
-                .WithMessage(localizer["NameCannotBeEmpty"]);
-            });
-
-            When(vm => vm.StandardHasOptions, () =>
-            {
-                RuleFor(vm => vm.Option).NotNull()
-                    .WithMessage(localizer["SelectAnOption"]);
+                    .WithMessage(localizer["NameCannotBeEmpty"]);
             });
         }
     }

--- a/src/SFA.DAS.AssessorService.Web/Views/Certificate/Check.cshtml
+++ b/src/SFA.DAS.AssessorService.Web/Views/Certificate/Check.cshtml
@@ -40,7 +40,10 @@ else
                     </h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
+                            <li><a sfa-validation-for="Version"></a></li>
                             <li><a sfa-validation-for="Option"></a></li>
+                            <li><a sfa-validation-for="SelectedGrade"></a></li>
+                            <li><a sfa-validation-for="AchievementDate"></a></li>
                             <li><a sfa-validation-for="Name"></a></li>
                             <li><a sfa-validation-for="Dept"></a></li>
                             <li><a sfa-validation-for="Employer"></a></li>
@@ -128,6 +131,7 @@ else
                         Version
                     </dt>
                     <dd class="govuk-summary-list__value">
+                        <span id="Option" class="govuk-error-message" asp-validation-for="Version"></span>
                         @Model.Version
                     </dd>
                     <dd class="govuk-summary-list__actions">
@@ -166,6 +170,7 @@ else
                         Grade
                     </dt>
                     <dd class="govuk-summary-list__value">
+                        <span id="Option" class="govuk-error-message" asp-validation-for="SelectedGrade"></span>
                         @Model.SelectedGrade
                     </dd>
                     <dd class="govuk-summary-list__actions">
@@ -187,6 +192,7 @@ else
                         }
                     </dt>
                     <dd class="govuk-summary-list__value">
+                        <span id="Option" class="govuk-error-message" asp-validation-for="AchievementDate"></span>
                         @Model.AchievementDate?.ToSfaShortDateString()
                     </dd>
                     <dd class="govuk-summary-list__actions">

--- a/src/SFA.DAS.AssessorService.Web/Views/Certificate/Check.cshtml
+++ b/src/SFA.DAS.AssessorService.Web/Views/Certificate/Check.cshtml
@@ -318,6 +318,7 @@ else
                 @Html.HiddenFor(c => c.City)
                 @Html.HiddenFor(c => c.Postcode)
                 @Html.HiddenFor(c => c.Option)
+                @Html.HiddenFor(c => c.Version)
                 @Html.HiddenFor(c => c.StandardHasOptions)
                 <button type="submit" class="govuk-button">@Localizer["ContinueButton"]</button>
             </form>

--- a/src/SFA.DAS.AssessorService.Web/Views/Certificate/Check.cshtml
+++ b/src/SFA.DAS.AssessorService.Web/Views/Certificate/Check.cshtml
@@ -312,6 +312,7 @@ else
             <form class="js-disable-on-submit" method="post" asp-controller="CertificateCheck">
                 @Html.HiddenFor(c => c.Id)
                 @Html.HiddenFor(c => c.SelectedGrade)
+                @Html.HiddenFor(c => c.AchievementDate)
                 @Html.HiddenFor(c => c.Name)
                 @Html.HiddenFor(c => c.AddressLine1)
                 @Html.HiddenFor(c => c.City)


### PR DESCRIPTION
I've added validation for Grade, Version and Achievement date. 

The existing unit tests for the CertificateCheckController were getting complicated because it was loading different certificates for each scenario and used a concrete validator. I've now changed the controller tests to use a mocked validator to check if the redirection and update API calls are correct if the view model is valid or not and then added a set of tests on the validator itself. 