### PR TITLE
SV-507 external api get options

### DIFF
--- a/src/SFA.DAS.AssessorService.Api.Types/Models/Standards/StandardVersionOption.cs
+++ b/src/SFA.DAS.AssessorService.Api.Types/Models/Standards/StandardVersionOption.cs
@@ -4,8 +4,8 @@ namespace SFA.DAS.AssessorService.Api.Types.Models.Standards
     public class StandardVersionOption
     {
         public string StandardUId { get; set; }
-        public int StandardCode { get; set; }
-        public string StandardReference { get; set; }
+        public int LarsCode { get; set; }
+        public string IfateReferenceNumber { get; set; }
         public string Version { get; set; }
         public string OptionName { get; set; }
     }

--- a/src/SFA.DAS.AssessorService.Api.Types/Models/Standards/StandardVersionOption.cs
+++ b/src/SFA.DAS.AssessorService.Api.Types/Models/Standards/StandardVersionOption.cs
@@ -1,0 +1,12 @@
+﻿
+namespace SFA.DAS.AssessorService.Api.Types.Models.Standards
+{
+    public class StandardVersionOption
+    {
+        public string StandardUId { get; set; }
+        public int StandardCode { get; set; }
+        public string StandardReference { get; set; }
+        public string Version { get; set; }
+        public string OptionName { get; set; }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/Controllers/StandardsControllerTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/Controllers/StandardsControllerTests.cs
@@ -38,7 +38,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.UnitTests.Controllers
         [Test, MoqAutoData]
         public async Task WhenRequestingStandardVersionOptions_And_StandardVersionWithOptionsIsFound_Then_ReturnStandard(string standardReference, string version, StandardOptions standardOptionsResponse)
         {
-            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version))
+            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardIdAndVersion(standardReference, version))
                 .ReturnsAsync(standardOptionsResponse);
 
             var result = await _controller.GetOptionsForStandardVersion(standardReference, version) as ObjectResult;
@@ -57,7 +57,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.UnitTests.Controllers
                 .With(s => s.CourseOption, new List<string>())
                 .Create();
 
-            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version))
+            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardIdAndVersion(standardReference, version))
                 .ReturnsAsync(standardOptionsResponse);
 
             var result = await _controller.GetOptionsForStandardVersion(standardReference, version) as NoContentResult;
@@ -68,7 +68,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.UnitTests.Controllers
         [Test, MoqAutoData]
         public async Task WhenRequestingStandardVersionOptions_And_StandardVersionIsNotFound_Then_ReturnNotFound(string standardReference, string version)
         {
-            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version))
+            _mockApiClient.Setup(client => client.GetStandardOptionsByStandardIdAndVersion(standardReference, version))
                 .ReturnsAsync((StandardOptions)null);
 
             var result = await _controller.GetOptionsForStandardVersion(standardReference, version) as NotFoundResult;

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/CertificateController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/CertificateController.cs
@@ -62,7 +62,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Controllers
             {
                 var certificateData = response.Certificate.CertificateData;
 
-                var options = await _apiClient.GetStandardOptionsByStandardReferenceAndVersion(certificateData.Standard.StandardReference, certificateData.LearningDetails.Version);
+                var options = await _apiClient.GetStandardOptionsByStandardIdAndVersion(certificateData.Standard.StandardReference, certificateData.LearningDetails.Version);
 
                 if (CertificateHelpers.IsDraftCertificateDeemedAsReady(response.Certificate, options?.CourseOption))
                 {

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
@@ -33,16 +33,16 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Controllers
         [SwaggerResponseExample((int)HttpStatusCode.OK, typeof(SwaggerHelpers.Examples.GetOptionsForAllStandardResponseExample))]
         [SwaggerResponse((int)HttpStatusCode.OK, "The list of options for each Standard.", typeof(IEnumerable<StandardOptions>))]
         [SwaggerOperation("Get Options", "Gets the latest list of course options by Standard.", Produces = new string[] { "application/json" })]
-        public async Task<IActionResult> GetOptionsForAllStandards()
+        public async Task<IActionResult> GetStandardOptionsForLatestStandardVersions()
         {
-            var standards = await _apiClient.GetStandardOptionsList();
+            var standards = await _apiClient.GetStandardOptionsForLatestStandardVersions();
 
             if(standards is null)
             {
                 return StatusCode((int)HttpStatusCode.ServiceUnavailable);
             }
 
-            return Ok(standards.Where(s => s.CourseOption != null && s.CourseOption.Any()).OrderBy(s => s.StandardCode));
+            return Ok(standards);
         }
 
         [HttpGet("options/{*standard}")]

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Controllers/StandardsController.cs
@@ -67,15 +67,15 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Controllers
             return Ok(requestedStandard);
         }
 
-        [HttpGet("options/{standardReference}/{version}")]
+        [HttpGet("options/{standard}/{version}")]
         [SwaggerResponseExample((int)HttpStatusCode.OK, typeof(SwaggerHelpers.Examples.GetStandardVersionOptionsResponseExample))]
         [SwaggerResponse((int)HttpStatusCode.OK, "The list of options.", typeof(StandardOptions))]
         [SwaggerResponse((int)HttpStatusCode.NoContent, "The standard version was found, however it has no options.")]
         [SwaggerResponse((int)HttpStatusCode.NotFound, "The standard version was not found.")]
         [SwaggerOperation("Get Options for a standard version", "Gets the latest list of course options for the specified Standard version.", Produces = new string[] { "application/json" })]
-        public async Task<IActionResult> GetOptionsForStandardVersion(string standardReference, string version)
+        public async Task<IActionResult> GetOptionsForStandardVersion([SwaggerParameter("Standard Code or Standard Reference Number")] string standard, string version)
         {
-            var standardVersion = await _apiClient.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+            var standardVersion = await _apiClient.GetStandardOptionsByStandardIdAndVersion(standard, version);
 
             if (standardVersion is null)
             {

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
@@ -212,9 +212,9 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
             return apiResponse;
         }
 
-        public virtual async Task<IEnumerable<StandardOptions>> GetStandardOptionsList()
+        public virtual async Task<IEnumerable<StandardOptions>> GetStandardOptionsForLatestStandardVersions()
         {
-            var response = await Get<IEnumerable<StandardOptions>>("/api/v1/standard-version/standard-options");
+            var response = await Get<IEnumerable<StandardOptions>>("/api/v1/standard-version/standard-options/latest-version");
 
             return response;
         }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
@@ -226,9 +226,9 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
             return response;
         }
 
-        public virtual async Task<StandardOptions> GetStandardOptionsByStandardIdAndVersion(string standardReference, string version)
+        public virtual async Task<StandardOptions> GetStandardOptionsByStandardIdAndVersion(string standard, string version)
         {
-            var response = await Get<StandardOptions>($"/api/v1/standard-version/standard-options/{standardReference}/{version}");
+            var response = await Get<StandardOptions>($"/api/v1/standard-version/standard-options/{standard}/{version}");
 
             return response;
         }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/ApiClient.cs
@@ -226,7 +226,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
             return response;
         }
 
-        public virtual async Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version)
+        public virtual async Task<StandardOptions> GetStandardOptionsByStandardIdAndVersion(string standardReference, string version)
         {
             var response = await Get<StandardOptions>($"/api/v1/standard-version/standard-options/{standardReference}/{version}");
 

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/IApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/IApiClient.cs
@@ -22,6 +22,6 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
 
         Task<IEnumerable<StandardOptions>> GetStandardOptionsForLatestStandardVersions();
         Task<StandardOptions> GetStandardOptionsByStandard(string standard);
-        Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version);
+        Task<StandardOptions> GetStandardOptionsByStandardIdAndVersion(string standard, string version);
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/IApiClient.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/Infrastructure/IApiClient.cs
@@ -20,7 +20,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.Infrastructure
         Task<IEnumerable<SubmitCertificateResponse>> SubmitCertificates(IEnumerable<SubmitBatchCertificateRequest> request);
         Task<ApiResponse> DeleteCertificate(DeleteBatchCertificateRequest request);
 
-        Task<IEnumerable<StandardOptions>> GetStandardOptionsList();
+        Task<IEnumerable<StandardOptions>> GetStandardOptionsForLatestStandardVersions();
         Task<StandardOptions> GetStandardOptionsByStandard(string standard);
         Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version);
     }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/SwaggerHelpers/Examples/GetOptionsForAllStandardResponseExample.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/SwaggerHelpers/Examples/GetOptionsForAllStandardResponseExample.cs
@@ -8,9 +8,9 @@ namespace SFA.DAS.AssessorService.Application.Api.External.SwaggerHelpers.Exampl
         public object GetExamples()
         {
             return new[] {
-                new StandardOptions { StandardCode = 6, StandardReference = "ST0156", CourseOption = new[] { "Overhead lines", "Substation fitting", "Underground cables" } },
-                new StandardOptions { StandardCode = 7, StandardReference = "ST0184", CourseOption = new[] { "Card services", "Corporate/Commercial", "Retail", "Wealth", } },
-                new StandardOptions { StandardCode = 314, StandardReference = "ST0018", CourseOption = new[] { "Container based system", "Soil based system" } }
+                new StandardOptions { StandardCode = 6, StandardReference = "ST0156", Version = "1.0", CourseOption = new[] { "Overhead lines", "Substation fitting", "Underground cables" } },
+                new StandardOptions { StandardCode = 7, StandardReference = "ST0184", Version = "1.0", CourseOption = new[] { "Card services", "Corporate/Commercial", "Retail", "Wealth", } },
+                new StandardOptions { StandardCode = 314, StandardReference = "ST0018", Version = "1.1", CourseOption = new[] { "Container based system", "Soil based system" } }
             };
         }
     }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/SwaggerHelpers/Examples/GetOptionsForStandardResponseExample.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/SwaggerHelpers/Examples/GetOptionsForStandardResponseExample.cs
@@ -7,7 +7,13 @@ namespace SFA.DAS.AssessorService.Application.Api.External.SwaggerHelpers.Exampl
     {
         public object GetExamples()
         {
-            return new StandardOptions { StandardCode = 6, StandardReference = "ST0156", CourseOption = new[] { "Overhead lines", "Substation fitting", "Underground cables" } };
+            return new StandardOptions 
+            { 
+                StandardCode = 6, 
+                StandardReference = "ST0156", 
+                Version = "1.0",
+                CourseOption = new[] { "Overhead lines", "Substation fitting", "Underground cables" } 
+            };
         }
     }
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/appsettings.json
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/appsettings.json
@@ -13,5 +13,5 @@
   },
   "EnvironmentName": "LOCAL",
   "InstanceName": "LOCAL",
-  "UseSandboxServices": false
+  "UseSandboxServices": true
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.External/appsettings.json
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/appsettings.json
@@ -13,5 +13,5 @@
   },
   "EnvironmentName": "LOCAL",
   "InstanceName": "LOCAL",
-  "UseSandboxServices": true
+  "UseSandboxServices": false
 }

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
@@ -64,7 +64,7 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
         [Test, AutoData]
         public async Task When_GettingStandardOptionsForLatestVersion_Then_ReturnsListOfStandardOptions(IEnumerable<StandardOptions> standardOptions)
         {
-            _mockStandardRepository.Setup(s => s.GetAllStandardOptions()).ReturnsAsync(standardOptions);
+            _mockStandardRepository.Setup(s => s.GetStandardOptionsForLatestStandardVersions()).ReturnsAsync(standardOptions);
 
             var result = await _standardService.GetStandardOptionsForLatestStandardVersions();
 

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
@@ -137,14 +137,29 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
         }
 
         [Test, AutoData]
-        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_StandardIsRetrievedFromAssessorStandardsTable(string standardReference, string version, Standard getStandardResponse)
+        public async Task When_GettingStandardOptionsByStandardIdAndVersion_And_IdIsIfateReferenceNumber_Then_StandardIsRetrievedFromAssessorStandardsTable(string version, Standard getStandardResponse)
         {
-            _mockStandardRepository.Setup(repository => repository.GetStandardVersionByIFateReferenceNumber(standardReference, version))
+            var id = "ST0001";
+
+            _mockStandardRepository.Setup(repository => repository.GetStandardVersionByIFateReferenceNumber(id, version))
                 .ReturnsAsync(getStandardResponse);
 
-            await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+            await _standardService.GetStandardOptionsByStandardIdAndVersion(id, version);
 
-            _mockStandardRepository.Verify(repository => repository.GetStandardVersionByIFateReferenceNumber(standardReference, version), Times.Once);
+            _mockStandardRepository.Verify(repository => repository.GetStandardVersionByIFateReferenceNumber(id, version), Times.Once);
+        }
+
+        [Test, AutoData]
+        public async Task When_GettingStandardOptionsByStandardIdAndVersion_And_IdIsLarsCode_Then_StandardIsRetrievedFromAssessorStandardsTable(string version, Standard getStandardResponse)
+        {
+            var id = "1";
+
+            _mockStandardRepository.Setup(repository => repository.GetStandardVersionByLarsCode(int.Parse(id), version))
+                .ReturnsAsync(getStandardResponse);
+
+            await _standardService.GetStandardOptionsByStandardIdAndVersion(id, version);
+
+            _mockStandardRepository.Verify(repository => repository.GetStandardVersionByLarsCode(int.Parse(id), version), Times.Once);
         }
 
         [Test, AutoData]
@@ -153,7 +168,7 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
             _mockStandardRepository.Setup(repository => repository.GetStandardVersionByIFateReferenceNumber(It.IsAny<string>(), It.IsAny<string>()))
                 .Throws(new Exception());
 
-            var result = await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+            var result = await _standardService.GetStandardOptionsByStandardIdAndVersion(standardReference, version);
             
             _mockLogger.Verify(logger => logger.Log(LogLevel.Error, It.IsAny<EventId>(),
                     It.IsAny<FormattedLogValues>(),
@@ -165,14 +180,31 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
         }
 
         [Test, AutoData]
-        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_UseStandardUIdToCallOuterApi(string standardReference, string version, Standard getStandardResponse, StandardOptions option)
+        public async Task When_GettingStandardOptionsByStandardReferenceAndVersion_Then_UseStandardUIdToCallOuterApi(string version, Standard getStandardResponse, StandardOptions option)
         {
+            var standardReference = "ST0001";
+
             _mockStandardRepository.Setup(repository => repository.GetStandardVersionByIFateReferenceNumber(standardReference, version))
                 .ReturnsAsync(getStandardResponse);
 
             _mockStandardRepository.Setup(repository => repository.GetStandardOptionsByStandardUId(getStandardResponse.StandardUId)).ReturnsAsync(option);
 
-            var result = await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+            var result = await _standardService.GetStandardOptionsByStandardIdAndVersion(standardReference, version);
+
+            result.Should().BeEquivalentTo(option);
+        }
+
+        [Test, AutoData]
+        public async Task When_GettingStandardOptionsByLarsCodeAndVersion_Then_UseStandardUIdToCallOuterApi(string version, Standard getStandardResponse, StandardOptions option)
+        {
+            var standardId = "1";
+
+            _mockStandardRepository.Setup(repository => repository.GetStandardVersionByLarsCode(int.Parse(standardId), version))
+                .ReturnsAsync(getStandardResponse);
+
+            _mockStandardRepository.Setup(repository => repository.GetStandardOptionsByStandardUId(getStandardResponse.StandardUId)).ReturnsAsync(option);
+
+            var result = await _standardService.GetStandardOptionsByStandardIdAndVersion(standardId, version);
 
             result.Should().BeEquivalentTo(option);
         }

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/Services/StandardServiceTests.cs
@@ -7,13 +7,11 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.AssessorService.Api.Types.Models.Standards;
 using SFA.DAS.AssessorService.Application.Api.Services;
-using SFA.DAS.AssessorService.Application.Infrastructure.OuterApi;
 using SFA.DAS.AssessorService.Application.Interfaces;
 using SFA.DAS.AssessorService.Domain.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
@@ -61,6 +59,33 @@ namespace SFA.DAS.AssessorService.Application.Api.UnitTests.Services
                     It.IsAny<Exception>(), 
                     It.IsAny<Func<object, Exception, string>>()), 
                 Times.Once, "STANDARD OPTIONS: Failed to get standard options");
+        }
+
+        [Test, AutoData]
+        public async Task When_GettingStandardOptionsForLatestVersion_Then_ReturnsListOfStandardOptions(IEnumerable<StandardOptions> standardOptions)
+        {
+            _mockStandardRepository.Setup(s => s.GetAllStandardOptions()).ReturnsAsync(standardOptions);
+
+            var result = await _standardService.GetStandardOptionsForLatestStandardVersions();
+
+            Assert.IsInstanceOf<IEnumerable<StandardOptions>>(result);
+            Assert.AreEqual(result.Count(), standardOptions.Count());
+        }
+
+        [Test]
+        public async Task When_GettingStandardOptionsForLatestVersionThrowsException_Then_LogError_And_ReturnNull()
+        {
+            _mockStandardRepository.Setup(s => s.GetStandardOptionsForLatestStandardVersions()).Throws<TimeoutException>();
+
+            var result = await _standardService.GetStandardOptionsForLatestStandardVersions();
+
+            Assert.IsNull(result);
+
+            _mockLogger.Verify(logger => logger.Log(LogLevel.Error, It.IsAny<EventId>(),
+                    It.IsAny<FormattedLogValues>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<object, Exception, string>>()),
+                Times.Once);
         }
 
         [Test, AutoData]

--- a/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardVersionController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardVersionController.cs
@@ -88,6 +88,17 @@ namespace SFA.DAS.AssessorService.Application.Api.Controllers
             return Ok(standardOptions);
         }
 
+        [HttpGet("standard-options/latest-version", Name = "GetStandardOptionsForLatestStandardVersions")]
+        [SwaggerResponse((int)HttpStatusCode.OK, Type = typeof(IEnumerable<StandardOptions>))]
+        [SwaggerResponse((int)HttpStatusCode.BadRequest, Type = typeof(IDictionary<string, string>))]
+        [SwaggerResponse((int)HttpStatusCode.InternalServerError, Type = typeof(ApiResponse))]
+        public async Task<IActionResult> GetStandardOptionsForLatestStandardVersions()
+        {
+            _logger.LogInformation("Get standard options for latest version of each standard from Standard Service");
+            var standardOptions = await _standardService.GetStandardOptionsForLatestStandardVersions();
+            return Ok(standardOptions);
+        }
+
         [HttpGet("standard-options/{id}", Name = "GetStandardOptionsByStandardId")]
         [SwaggerResponse((int)HttpStatusCode.OK, Type = typeof(StandardOptions))]
         [SwaggerResponse((int)HttpStatusCode.BadRequest, Type = typeof(IDictionary<string, string>))]

--- a/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardVersionController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardVersionController.cs
@@ -117,7 +117,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Controllers
         public async Task<IActionResult> GetStandardOptionsForStandardReferenceAndVersion(string standardReference, string version)
         {
             _logger.LogInformation($"Get standard options from Standard Service for standard with standard reference {standardReference} and verion {version}");
-            var standardOptions = await _standardService.GetStandardOptionsByStandardReferenceAndVersion(standardReference, version);
+            var standardOptions = await _standardService.GetStandardOptionsByStandardIdAndVersion(standardReference, version);
             return Ok(standardOptions);
         }
 

--- a/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardVersionController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Controllers/StandardVersionController.cs
@@ -110,14 +110,14 @@ namespace SFA.DAS.AssessorService.Application.Api.Controllers
             return Ok(standardOptions);
         }
 
-        [HttpGet("standard-options/{standardReference}/{version}", Name = "GetStandardOptionsByStandardReferenceAndVersion")]
+        [HttpGet("standard-options/{standardId}/{version}", Name = "GetStandardOptionsByStandardIdAndVersion")]
         [SwaggerResponse((int)HttpStatusCode.OK, Type = typeof(StandardOptions))]
         [SwaggerResponse((int)HttpStatusCode.BadRequest, Type = typeof(IDictionary<string, string>))]
         [SwaggerResponse((int)HttpStatusCode.InternalServerError, Type = typeof(ApiResponse))]
-        public async Task<IActionResult> GetStandardOptionsForStandardReferenceAndVersion(string standardReference, string version)
+        public async Task<IActionResult> GetStandardOptionsForStandardIdAndVersion(string standardId, string version)
         {
-            _logger.LogInformation($"Get standard options from Standard Service for standard with standard reference {standardReference} and verion {version}");
-            var standardOptions = await _standardService.GetStandardOptionsByStandardIdAndVersion(standardReference, version);
+            _logger.LogInformation($"Get standard options from Standard Service for standard {standardId} and verion {version}");
+            var standardOptions = await _standardService.GetStandardOptionsByStandardIdAndVersion(standardId, version);
             return Ok(standardOptions);
         }
 

--- a/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
@@ -170,7 +170,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "STANDARD OPTIONS: Failed to get latest version of each standard");
+                _logger.LogError(ex, "STANDARD OPTIONS: Failed to get options for latest version of each standard");
             }
 
             return null;
@@ -203,17 +203,27 @@ namespace SFA.DAS.AssessorService.Application.Api.Services
             return options;
         }
 
-        public async Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version)
+        public async Task<StandardOptions> GetStandardOptionsByStandardIdAndVersion(string id, string version)
         {
-            Standard standard;
+            Standard standard = new Standard();
 
             try
             {
-                standard = await _standardRepository.GetStandardVersionByIFateReferenceNumber(standardReference, version);
+                var standardId = new StandardId(id);
+
+                switch (standardId.IdType)
+                {
+                    case StandardId.StandardIdType.IFateReferenceNumber:
+                        standard = await _standardRepository.GetStandardVersionByIFateReferenceNumber(standardId.IFateReferenceNumber, version);
+                        break;
+                    case StandardId.StandardIdType.LarsCode:
+                        standard = await _standardRepository.GetStandardVersionByLarsCode(standardId.LarsCode, version);
+                        break;
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Could not find standard with StandardReference: {standardReference} and Version: {version}");
+                _logger.LogError(ex, $"Could not find standard with id: {id} and Version: {version}");
 
                 return null;
             }

--- a/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Services/StandardService.cs
@@ -160,6 +160,22 @@ namespace SFA.DAS.AssessorService.Application.Api.Services
             return null;
         }
 
+        public async Task<IEnumerable<StandardOptions>> GetStandardOptionsForLatestStandardVersions()
+        {
+            try
+            {
+                var options = await _standardRepository.GetStandardOptionsForLatestStandardVersions();
+
+                return options;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "STANDARD OPTIONS: Failed to get latest version of each standard");
+            }
+
+            return null;
+        }
+
         public async Task<StandardOptions> GetStandardOptionsByStandardId(string id)
         {
             StandardOptions options = null;

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardRepository.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardRepository.cs
@@ -48,6 +48,7 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
         Task InsertStandards(IEnumerable<Standard> standard);
         Task InsertOptions(IEnumerable<StandardOption> optionsToInsert);
         Task<IEnumerable<StandardOptions>> GetAllStandardOptions();
+        Task<IEnumerable<StandardOptions>> GetStandardOptionsForLatestStandardVersions();
         Task<StandardOptions> GetStandardOptionsByStandardUId(string standardUId);
         Task<StandardOptions> GetStandardOptionsByLarsCode(int larsCode);
         Task<StandardOptions> GetStandardOptionsByIFateReferenceNumber(string iFateReferenceNumber);

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardService.cs
@@ -29,7 +29,7 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
         Task<IEnumerable<StandardOptions>> GetAllStandardOptions();
         Task<IEnumerable<StandardOptions>> GetStandardOptionsForLatestStandardVersions();
         Task<StandardOptions> GetStandardOptionsByStandardId(string id);
-        Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version);
+        Task<StandardOptions> GetStandardOptionsByStandardIdAndVersion(string id, string version);
         Task<IEnumerable<StandardVersion>> GetEPAORegisteredStandardVersions(string endPointAssessorOrganisationId, int? larsCode);
     }
 }

--- a/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardService.cs
+++ b/src/SFA.DAS.AssessorService.Application/Interfaces/IStandardService.cs
@@ -27,6 +27,7 @@ namespace SFA.DAS.AssessorService.Application.Interfaces
         /// <returns></returns>
         Task<Standard> GetStandardVersionById(string standardId, string version = null);
         Task<IEnumerable<StandardOptions>> GetAllStandardOptions();
+        Task<IEnumerable<StandardOptions>> GetStandardOptionsForLatestStandardVersions();
         Task<StandardOptions> GetStandardOptionsByStandardId(string id);
         Task<StandardOptions> GetStandardOptionsByStandardReferenceAndVersion(string standardReference, string version);
         Task<IEnumerable<StandardVersion>> GetEPAORegisteredStandardVersions(string endPointAssessorOrganisationId, int? larsCode);

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/GetStandardOptionsTests.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/GetStandardOptionsTests.cs
@@ -23,6 +23,8 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests
         private List<StandardOptionModel> _options;
         private List<StandardModel> _standards;
 
+        private StandardOptions _expectedStandardResult;
+
         [OneTimeSetUp]
         public void SetupStandardOptionsTable()
         {
@@ -35,28 +37,37 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests
 
             StandardOptionsHandler.InsertRecords(_options);
             StandardsHandler.InsertRecords(_standards);
+
+            _expectedStandardResult = new StandardOptions
+            {
+                StandardUId = "ST0001_1.1",
+                StandardReference = "ST0001",
+                StandardCode = 1,
+                Version = "1.1",
+                CourseOption = new List<string>
+                {
+                    "ST0001_1.1 Option 1",
+                    "ST0001_1.1 Option 2"
+                }
+            };
         }
 
         [Test]
         public async Task GetAllStandardOptions_ReturnsFullListOfStandardOptions()
         {
-            var expectedOptions = _options.Where(option => option.StandardUId == "ST0001_1.0").Select(option => option.OptionName).ToList();
-
             var results = await _repository.GetAllStandardOptions();
 
             results.Count().Should().Be(_standards.Count);
-            results.First(result => result.StandardUId == "ST0001_1.0").CourseOption.Should().Contain(expectedOptions);
+            results.First(result => result.StandardUId == "ST0001_1.1").Should().BeEquivalentTo(_expectedStandardResult);
         }
 
         [Test]
         public async Task GetLatestVersionStandardOptions_ReturnsListOfStandardOptions()
         {
-            var expectedOptions = _options.Where(option => option.StandardUId == "ST0001_1.1").Select(option => option.OptionName);
-
             var results = await _repository.GetStandardOptionsForLatestStandardVersions();
 
             results.Count().Should().Be(2);
-            results.First(result => result.StandardUId == "ST0001_1.1").CourseOption.Should().Contain(expectedOptions);
+            results.First(result => result.StandardUId == "ST0001_1.1").Should().BeEquivalentTo(_expectedStandardResult);
         }
 
         [OneTimeTearDown]
@@ -91,6 +102,7 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests
                 {
                     StandardUId = "ST0001_1.0",
                     IFateReferenceNumber = "ST0001",
+                    LarsCode = 1,
                     Version = 1.0m,
                     Title = "Standard",
                     Level = 4,
@@ -105,6 +117,7 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests
                 {
                     StandardUId = "ST0001_1.1",
                     IFateReferenceNumber = "ST0001",
+                    LarsCode = 1,
                     Version = 1.1m,
                     Title = "Standard",
                     Level = 4,
@@ -119,6 +132,7 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests
                 {
                     StandardUId = "ST0002_1.0",
                     IFateReferenceNumber = "ST0002",
+                    LarsCode = 2,
                     Version = 1.0m,
                     Title = "Standard",
                     Level = 4,
@@ -133,6 +147,7 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests
                 {
                     StandardUId = "ST0003_1.0",
                     IFateReferenceNumber = "ST0003",
+                    LarsCode = 3,
                     Version = 1.0m,
                     Title = "Standard",
                     Level = 4,

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/GetStandardOptionsTests.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/GetStandardOptionsTests.cs
@@ -1,0 +1,149 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models.Standards;
+using SFA.DAS.AssessorService.Data.IntegrationTests.Handlers;
+using SFA.DAS.AssessorService.Data.IntegrationTests.Models;
+using SFA.DAS.AssessorService.Data.IntegrationTests.Services;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Data.IntegrationTests
+{
+    [TestFixture]
+    public class GetStandardOptionsTests : TestBase
+    {
+        private readonly DatabaseService _databaseService = new DatabaseService();
+
+        private SqlConnection _databaseConnection;
+        private UnitOfWork _unitOfWork;
+        private StandardRepository _repository;
+
+        private List<StandardOptionModel> _options;
+        private List<StandardModel> _standards;
+
+        [OneTimeSetUp]
+        public void SetupStandardOptionsTable()
+        {
+            _databaseConnection = new SqlConnection(_databaseService.WebConfiguration.SqlConnectionString);
+            _unitOfWork = new UnitOfWork(_databaseConnection);
+            _repository = new StandardRepository(_unitOfWork);
+
+            _options = GetListOfOptions();
+            _standards = GetListOfStandardVersions();
+
+            StandardOptionsHandler.InsertRecords(_options);
+            StandardsHandler.InsertRecords(_standards);
+        }
+
+        [Test]
+        public async Task GetAllStandardOptions_ReturnsFullListOfStandardOptions()
+        {
+            var expectedOptions = _options.Where(option => option.StandardUId == "ST0001_1.0").Select(option => option.OptionName).ToList();
+
+            var results = await _repository.GetAllStandardOptions();
+
+            results.Count().Should().Be(_standards.Count);
+            results.First(result => result.StandardUId == "ST0001_1.0").CourseOption.Should().Contain(expectedOptions);
+        }
+
+        [Test]
+        public async Task GetLatestVersionStandardOptions_ReturnsListOfStandardOptions()
+        {
+            var expectedOptions = _options.Where(option => option.StandardUId == "ST0001_1.1").Select(option => option.OptionName);
+
+            var results = await _repository.GetStandardOptionsForLatestStandardVersions();
+
+            results.Count().Should().Be(2);
+            results.First(result => result.StandardUId == "ST0001_1.1").CourseOption.Should().Contain(expectedOptions);
+        }
+
+        [OneTimeTearDown]
+        public void TearDownTables()
+        {
+            StandardOptionsHandler.DeleteAllRecords();
+            StandardsHandler.DeleteAllRecords();
+
+            if (_databaseConnection != null)
+            {
+                _databaseConnection.Dispose();
+            }
+        }
+
+        private List<StandardOptionModel> GetListOfOptions()
+        {
+            return new List<StandardOptionModel>
+            {
+                new StandardOptionModel { StandardUId = "ST0001_1.0", OptionName = "ST0001_1.0 Option 1" },
+                new StandardOptionModel { StandardUId = "ST0001_1.0", OptionName = "ST0001_1.0 Option 2" },
+                new StandardOptionModel { StandardUId = "ST0001_1.1", OptionName = "ST0001_1.1 Option 1" },
+                new StandardOptionModel { StandardUId = "ST0001_1.1", OptionName = "ST0001_1.1 Option 2" },
+                new StandardOptionModel { StandardUId = "ST0002_1.0", OptionName = "ST0002_1.0 Option 1" },
+                new StandardOptionModel { StandardUId = "ST0002_1.0", OptionName = "ST0002_1.0 Option 2" }
+            };
+        }
+
+        private List<StandardModel> GetListOfStandardVersions()
+        {
+            return new List<StandardModel>{
+                new StandardModel
+                {
+                    StandardUId = "ST0001_1.0",
+                    IFateReferenceNumber = "ST0001",
+                    Version = 1.0m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                },
+                new StandardModel
+                {
+                    StandardUId = "ST0001_1.1",
+                    IFateReferenceNumber = "ST0001",
+                    Version = 1.1m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                },
+                 new StandardModel
+                {
+                    StandardUId = "ST0002_1.0",
+                    IFateReferenceNumber = "ST0002",
+                    Version = 1.0m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                },
+                new StandardModel
+                {
+                    StandardUId = "ST0003_1.0",
+                    IFateReferenceNumber = "ST0003",
+                    Version = 1.0m,
+                    Title = "Standard",
+                    Level = 4,
+                    Status = "Active",
+                    IsActive = 1,
+                    MaxFunding = 10000,
+                    TypicalDuration = 12,
+                    ProposedMaxFunding = 10000,
+                    ProposedTypicalDuration = 12
+                }
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/Handlers/StandardOptionsHandler.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/Handlers/StandardOptionsHandler.cs
@@ -1,0 +1,39 @@
+﻿using SFA.DAS.AssessorService.Data.IntegrationTests.Models;
+using SFA.DAS.AssessorService.Data.IntegrationTests.Services;
+using System.Collections.Generic;
+
+namespace SFA.DAS.AssessorService.Data.IntegrationTests.Handlers
+{
+    public class StandardOptionsHandler
+    {
+        private static readonly DatabaseService DatabaseService = new DatabaseService();
+
+        public static void InsertRecord(StandardOptionModel standardOption)
+        {
+            var sqlToInsertOption =
+                "INSERT INTO [dbo].[StandardOptions] " +
+                    "([StandardUId], " +
+                    "[OptionName]) " +
+                "VALUES " +
+                    "(@StandardUId, " +
+                    "@optionName)";
+
+            DatabaseService.Execute(sqlToInsertOption, standardOption);
+        }
+
+        public static void InsertRecords(List<StandardOptionModel> options)
+        {
+            foreach (var option in options)
+            {
+                InsertRecord(option);
+            }
+        }
+
+        public static void DeleteAllRecords()
+        {
+            var sql = "DELETE FROM [StandardOptions]";
+
+            DatabaseService.Execute(sql);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/Handlers/StandardsHandler.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/Handlers/StandardsHandler.cs
@@ -14,6 +14,7 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests.Handlers
                 "INSERT INTO [dbo].[Standards]" +
                     "([StandardUId]" +
                     ", [IFateReferenceNumber]" +
+                    ", [LarsCode]" +
                     ", [Version]" +
                     ", [Title]" +
                     ", [Level]" +
@@ -26,6 +27,7 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests.Handlers
                 "VALUES " +
                     "(@StandardUId" +
                     ", @iFateReferenceNumber" +
+                    ", @larsCode" +
                     ", @version" +
                     ", @title" +
                     ", @level" +

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/Models/StandardModel.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/Models/StandardModel.cs
@@ -5,6 +5,7 @@ namespace SFA.DAS.AssessorService.Data.IntegrationTests.Models
     {
         public string StandardUId { get; set; }
         public string IFateReferenceNumber { get; set; }
+        public int LarsCode { get; set; }
         public decimal Version { get; set; }
         public int Level { get; set; }
         public string Title { get; set; }

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/Models/StandardOptionModel.cs
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/Models/StandardOptionModel.cs
@@ -1,0 +1,9 @@
+﻿
+namespace SFA.DAS.AssessorService.Data.IntegrationTests.Models
+{
+    public class StandardOptionModel : TestModel
+    {
+        public string StandardUId { get; set; }
+        public string OptionName { get; set; }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Data/StandardRepository.cs
+++ b/src/SFA.DAS.AssessorService.Data/StandardRepository.cs
@@ -220,14 +220,14 @@ namespace SFA.DAS.AssessorService.Data
             var results = standardVersionOptions.GroupBy(version => new 
                 { 
                     version.StandardUId, 
-                    version.StandardCode, 
-                    version.StandardReference, 
+                    version.LarsCode, 
+                    version.IfateReferenceNumber, 
                     version.Version 
                 })
                 .Select(group => new StandardOptions { 
                     StandardUId = group.Key.StandardUId,
-                    StandardReference = group.Key.StandardReference,
-                    StandardCode = group.Key.StandardCode,
+                    StandardReference = group.Key.IfateReferenceNumber,
+                    StandardCode = group.Key.LarsCode,
                     Version = group.Key.Version,
                     CourseOption = group.Select(opt => opt.OptionName)
                 });

--- a/src/SFA.DAS.AssessorService.Data/StandardRepository.cs
+++ b/src/SFA.DAS.AssessorService.Data/StandardRepository.cs
@@ -316,7 +316,7 @@ namespace SFA.DAS.AssessorService.Data
                 param: new { ifateReferenceNumber, version },
                 transaction: _unitOfWork.Transaction);
 
-            return results.FirstOrDefault();
+            return results.First();
         }
 
         private async Task<Standard> GetStandardByLarsCodeAndVersionInternal(int larsCode, string version)
@@ -331,7 +331,7 @@ namespace SFA.DAS.AssessorService.Data
                 param: new { larsCode, version },
                 transaction: _unitOfWork.Transaction);
 
-            return results.FirstOrDefault();
+            return results.First();
         }
 
         public async Task<List<Option>> GetOptions(int stdCode)


### PR DESCRIPTION
I've added a new GetStandardOptionsForLatestStandardVersions to the internal API with a specific query, repository + service methods to return only the latest standard versions which have options. 

The External API was changed to call the new internal API method as GET ALL versions is not required for the external API but GET ALL is still used in the internal API