### PR TITLE
Removed dependsOn resource group deployment in sandbox-template.json

### DIFF
--- a/azure/sandbox-template.json
+++ b/azure/sandbox-template.json
@@ -124,10 +124,7 @@
                         "value": "[parameters('aspInstances')]"
                     }
                 }
-            },
-            "dependsOn": [
-                "[variables('resourceGroupName')]"
-            ]
+            }
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -182,10 +179,7 @@
                         "value": "[parameters('sharedManagementResourceGroup')]"
                     }
                 }
-            },
-            "dependsOn": [
-                "[variables('resourceGroupName')]"
-            ]
+            }
         },
         {
             "apiVersion": "2020-10-01",
@@ -210,10 +204,7 @@
                         "value": "[parameters('sharedManagementResourceGroup')]"
                     }
                 }
-            },
-            "dependsOn": [
-                "[variables('resourceGroupName')]"
-            ]
+            }
         },
         {
             "apiVersion": "2020-10-01",
@@ -398,10 +389,7 @@
                         "value": "[variables('externalApiActiveSandboxAppServiceName')]"
                     }
                 }
-            },
-            "dependsOn": [
-                "[variables('resourceGroupName')]"
-            ]
+            }
         },
         {
             "apiVersion": "2020-10-01",
@@ -423,10 +411,7 @@
                         "value": "[variables('internalApiActiveSandboxAppServiceName')]"
                     }
                 }
-            },
-            "dependsOn": [
-                "[variables('resourceGroupName')]"
-            ]
+            }
         },
         {
             "apiVersion": "2020-10-01",


### PR DESCRIPTION
Removed dependsOn resource group deployment in sandbox-template.json

- Resource group is not deployed in sandbox-template.json so there should not be dependsOn for the resource group