### PR TITLE
SV-643 set the hyperlink destination on the results page

### DIFF
--- a/src/SFA.DAS.AssessorService.Web/ViewModels/Apply/StandardViewModel.cs
+++ b/src/SFA.DAS.AssessorService.Web/ViewModels/Apply/StandardViewModel.cs
@@ -19,6 +19,8 @@ namespace SFA.DAS.AssessorService.Web.ViewModels.Apply
         public bool IsConfirmed { get; set; }
 
         public string ApplicationStatus { get; set; }
+
+        public Dictionary<string, bool> OrganisationHasStandardWithVersions { get; set; }
     }
 
 

--- a/src/SFA.DAS.AssessorService.Web/Views/Application/Standard/FindStandardResults.cshtml
+++ b/src/SFA.DAS.AssessorService.Web/Views/Application/Standard/FindStandardResults.cshtml
@@ -38,7 +38,16 @@
                                     <td class="govuk-table__cell" data-label="Name">@result.Title</td>
                                     <td class="govuk-table__cell" data-label="Reference">@result.ReferenceNumber</td>
                                     <td class="govuk-table__cell govuk-table__cell--numeric">
-                                        <a href="/standard/@Model.Id/confirm-standard/@result.StandardId" class="govuk-link">Apply for standard</a>
+
+                                        @if (Model.OrganisationHasStandardWithVersions[result.ReferenceNumber])
+                                        {
+                                            <a href="/standard/@Model.Id/confirm-standard-versions/@result.StandardId" class="govuk-link">Apply for standard</a>
+                                        }
+                                        else
+                                        {
+                                            <a href="/standard/@Model.Id/confirm-standard/@result.StandardId" class="govuk-link">Apply for standard</a>
+                                        }
+
                                     </td>
                                 </tr>
                             }


### PR DESCRIPTION
Set the hyperlink destination on the results page based on whether the organisation already has a standard version. Note that the new destination page itself does not exist yet, that is covered by SV-644

(cherry picked from commit 75aac55ca6d29e6d5caebae25c42d8a3db85525b)