### PR TITLE
SV-836 drop milliseconds from get learner data

### DIFF
--- a/src/SFA.DAS.AssessorService.Application.Api.External/AutoMapperProfiles/CertificateDataProfile.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/AutoMapperProfiles/CertificateDataProfile.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using SFA.DAS.AssessorService.Application.Api.External.Extenstions;
 
 namespace SFA.DAS.AssessorService.Application.Api.External.AutoMapperProfiles
 {
@@ -30,7 +31,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.AutoMapperProfiles
                 .ForPath(dest => dest.Learner.FamilyName, opt => opt.MapFrom(source => source.LearnerFamilyName))
                 .ForPath(dest => dest.Learner.GivenNames, opt => opt.MapFrom(source => source.LearnerGivenNames))
                 .ForPath(dest => dest.LearningDetails.Version, opt => opt.MapFrom(source => source.Version))
-                .ForPath(dest => dest.LearningDetails.AchievementDate, opt => opt.MapFrom(source => source.AchievementDate))
+                .ForPath(dest => dest.LearningDetails.AchievementDate, opt => opt.MapFrom(source => source.AchievementDate.DropMilliseconds()))
                 .ForPath(dest => dest.LearningDetails.CourseOption, opt => opt.MapFrom(source => source.CourseOption))
                 .ForPath(dest => dest.LearningDetails.Version, opt => {
                         opt.Condition(version => !string.IsNullOrEmpty(version.SourceMember));

--- a/src/SFA.DAS.AssessorService.Application.Api.External/AutoMapperProfiles/GetBatchLearnerResponseProfile.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/AutoMapperProfiles/GetBatchLearnerResponseProfile.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using Newtonsoft.Json;
 using SFA.DAS.AssessorService.Api.Types.Models.ExternalApi.Learners;
+using SFA.DAS.AssessorService.Application.Api.External.Extenstions;
 using SFA.DAS.AssessorService.Application.Api.External.Models.Response;
 using SFA.DAS.AssessorService.Application.Api.External.Models.Response.Certificates;
 using SFA.DAS.AssessorService.Application.Api.External.Models.Response.Epa;
@@ -56,8 +57,8 @@ namespace SFA.DAS.AssessorService.Application.Api.External.AutoMapperProfiles
                             LearnerReferenceNumber = source.Learner.LearnerReferenceNumber, 
                             ProviderUkPrn = source.Learner.UkPrn, 
                             ProviderName = source.Learner.OrganisationName, 
-                            LearningStartDate = source.Learner.LearnerStartDate, 
-                            PlannedEndDate = source.Learner.PlannedEndDate,
+                            LearningStartDate = source.Learner.LearnerStartDate.DropMilliseconds(), 
+                            PlannedEndDate = source.Learner.PlannedEndDate.DropMilliseconds(),
                             Version = GetVersionFromGetBatchLearnerResponse(source, destination),
                             CourseOption = GetCourseOptionFromGetBatchLearnerResponse(source, destination)
                         }
@@ -74,7 +75,7 @@ namespace SFA.DAS.AssessorService.Application.Api.External.AutoMapperProfiles
                         { 
                             ProviderUkPrn = certData.LearningDetails.ProviderUkPrn, 
                             ProviderName = certData.LearningDetails.ProviderName, 
-                            LearningStartDate = certData.LearningDetails.LearningStartDate
+                            LearningStartDate = certData.LearningDetails.LearningStartDate.DropMilliseconds()
                         }
                     };
                 }


### PR DESCRIPTION
I've reused the DropMilliseconds extension method to format get learner data and have also applied it to the Get Certificate Achievement date as the same bug would apply there too