### PR TITLE
Return versions in summary as CSV

### DIFF
--- a/src/SFA.DAS.AssessorService.Database/Functions/Table-valued Functions/Apply_Func_Get_Applications.sql
+++ b/src/SFA.DAS.AssessorService.Database/Functions/Table-valued Functions/Apply_Func_Get_Applications.sql
@@ -55,7 +55,7 @@ RETURN
         ap1.ReviewStatus As ReviewStatus,
 		ap1.ApplicationType as ApplicationType,
         ap1.FinancialReviewStatus As FinancialStatus,
-		JSON_VALUE(ap1.ApplyData, '$.Apply.Versions') as Versions,
+		TRIM(REPLACE(REPLACE(REPLACE(JSON_QUERY(ap1.ApplyData, '$.Apply.Versions'), '"', ''), '[', ''), ']', '')) as Versions,
         JSON_VALUE(ap1.FinancialGrade,'$.SelectedGrade') AS FinancialGrade,		
         seq.Status As SequenceStatus,
 		TotalCount = COUNT(1) OVER()


### PR DESCRIPTION
Apply.ApplyData.Versions is an object (array of strings).
ApplicationSummaryItem in the AssessorService API requires the "Versions" field to be a CSV string of version numbers if present.
This tweak to the stored function parses the array of strings from the json Versions field to return a CSV.
Not sure if there is a better way to unformat the json rather than the multiple REPLACEs.