### PR TITLE
SV-852 standard report

### DIFF
--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/StaffReports_ByStandard.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/StaffReports_ByStandard.sql
@@ -2,7 +2,8 @@
 AS
   SELECT
 		REPLACE(UPPER(REPLACE(JSON_VALUE(ce.[CertificateData], '$.StandardName'), NCHAR(0x00A0), ' ')), 'Á', ' ') AS 'Standard Name',
-		CONVERT(CHAR(10), ce.[StandardCode]) AS 'Standard Code',
+		JSON_VALUE(ce.CertificateData, '$.StandardReference') 'Standard Reference',
+		JSON_VALUE(ce.CertificateData, '$.Version') 'Standard Version',
 		COUNT(*) AS 'Total',
 		SUM(CASE WHEN ce.[CertificateReferenceId] < 10000 THEN 1 ELSE 0 END) AS 'Manual Total',
 		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 THEN 1 ELSE 0 END) AS 'EPA Service Total',
@@ -13,12 +14,13 @@ AS
 		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NULL AND ce.[Status] = 'Printed' THEN 1 ELSE 0 END) AS 'EPA Printed',
 		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NOT NULL THEN 1 ELSE 0 END) AS 'Deleted'
   FROM [dbo].[Certificates] ce
-  GROUP BY REPLACE(UPPER(REPLACE(JSON_VALUE(ce.[CertificateData], '$.StandardName'), NCHAR(0x00A0), ' ')), 'Á', ' '), ce.[StandardCode]
+  GROUP BY REPLACE(UPPER(REPLACE(JSON_VALUE(ce.[CertificateData], '$.StandardName'), NCHAR(0x00A0), ' ')), 'Á', ' '), ce.[StandardCode],  ce.CertificateData
 
   UNION 
   SELECT
 		' Summary' AS 'Standard Name',
-		''  AS 'Standard Code',
+		''  AS 'Standard Reference',
+		''  AS 'Standard Version',
 		COUNT(*) AS 'Total',
 		SUM(CASE WHEN ce.[CertificateReferenceId] < 10000 THEN 1 ELSE 0 END) AS 'Manual Total',
 		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 THEN 1 ELSE 0 END) AS 'EPA Service Total',

--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/StaffReports_ByStandard.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/StaffReports_ByStandard.sql
@@ -1,20 +1,41 @@
 ﻿CREATE PROCEDURE [dbo].[StaffReports_ByStandard]
 AS
-  SELECT
-		REPLACE(UPPER(REPLACE(JSON_VALUE(ce.[CertificateData], '$.StandardName'), NCHAR(0x00A0), ' ')), 'Á', ' ') AS 'Standard Name',
-		JSON_VALUE(ce.CertificateData, '$.StandardReference') 'Standard Reference',
-		JSON_VALUE(ce.CertificateData, '$.Version') 'Standard Version',
-		COUNT(*) AS 'Total',
-		SUM(CASE WHEN ce.[CertificateReferenceId] < 10000 THEN 1 ELSE 0 END) AS 'Manual Total',
-		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 THEN 1 ELSE 0 END) AS 'EPA Service Total',
-		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 And ce.[CreatedBy] <> 'manual' THEN 1 ELSE 0 END) AS 'EPA Service',
-		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 And ce.[CreatedBy] = 'manual' THEN 1 ELSE 0 END ) AS 'EPA Service Manual',
-		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NULL AND ce.[Status] = 'Draft' THEN 1 ELSE 0 END) AS 'EPA Draft',
-		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NULL AND ce.[Status] = 'Submitted' THEN 1 ELSE 0 END) AS 'EPA Submitted',
-		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NULL AND ce.[Status] = 'Printed' THEN 1 ELSE 0 END) AS 'EPA Printed',
-		SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NOT NULL THEN 1 ELSE 0 END) AS 'Deleted'
-  FROM [dbo].[Certificates] ce
-  GROUP BY REPLACE(UPPER(REPLACE(JSON_VALUE(ce.[CertificateData], '$.StandardName'), NCHAR(0x00A0), ' ')), 'Á', ' '), ce.[StandardCode],  ce.CertificateData
+select 
+st.[Standard Name], 
+st.[Standard Reference], 
+STRING_AGG(st.[Standard Version], ', ') WITHIN GROUP (ORDER BY CONVERT(decimal(5,2), st.[Standard Version]) ASC) [Standard Version], 
+SUM(st.Total) [Total], 
+SUM(st.[Manual Total]) [Manual Total], 
+SUM(st.[EPA Service Total]) [EPA Service Total], 
+SUM(st.[EPA Service]) [EPA Service], 
+SUM(st.[EPA Service Manual]) [EPA Service Manual], 
+SUM(st.[EPA Draft]) [EPA Draft], 
+SUM(st.[EPA Submitted]) [EPA Submitted], 
+SUM(st.[EPA Printed]) [EPA Printed], 
+SUM(st.Deleted) [Deleted]
+from
+(
+
+SELECT
+			REPLACE(UPPER(REPLACE(JSON_VALUE(ce.[CertificateData], '$.StandardName'), NCHAR(0x00A0), ' ')), 'Á', ' ') AS 'Standard Name',
+			JSON_VALUE(ce.CertificateData, '$.StandardReference') 'Standard Reference',
+			JSON_VALUE(ce.CertificateData, '$.Version') 'Standard Version',
+			COUNT(*) AS 'Total',
+			SUM(CASE WHEN ce.[CertificateReferenceId] < 10000 THEN 1 ELSE 0 END) AS 'Manual Total',
+			SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 THEN 1 ELSE 0 END) AS 'EPA Service Total',
+			SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 And ce.[CreatedBy] <> 'manual' THEN 1 ELSE 0 END) AS 'EPA Service',
+			SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 And ce.[CreatedBy] = 'manual' THEN 1 ELSE 0 END ) AS 'EPA Service Manual',
+			SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NULL AND ce.[Status] = 'Draft' THEN 1 ELSE 0 END) AS 'EPA Draft',
+			SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NULL AND ce.[Status] = 'Submitted' THEN 1 ELSE 0 END) AS 'EPA Submitted',
+			SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NULL AND ce.[Status] = 'Printed' THEN 1 ELSE 0 END) AS 'EPA Printed',
+			SUM(CASE WHEN ce.[CertificateReferenceId] >= 10000 AND ce.[DeletedAt] IS NOT NULL THEN 1 ELSE 0 END) AS 'Deleted'
+	  FROM [dbo].[Certificates] ce
+	  GROUP BY REPLACE(UPPER(REPLACE(JSON_VALUE(ce.[CertificateData], '$.StandardName'), NCHAR(0x00A0), ' ')), 'Á', ' '), ce.[StandardCode],  ce.CertificateData
+)
+as st
+group by st.[Standard Name], st.[Standard Reference]
+
+
 
   UNION 
   SELECT


### PR DESCRIPTION
Note - issue TBC:
- Requirement on screeen is that there is one row per standard per version
- Requirement in Excel is that one row per standard, with versions as CSV
Current code for reports uses same SP to populate both screen and Excel