### PR TITLE
SV-1216 Fix for Record-a-grade search when previous FAIL was recorded via API

### DIFF
--- a/src/SFA.DAS.AssessorService.Application/Handlers/Search/SearchResultExtensions.cs
+++ b/src/SFA.DAS.AssessorService.Application/Handlers/Search/SearchResultExtensions.cs
@@ -137,7 +137,7 @@ namespace SFA.DAS.AssessorService.Application.Handlers.Search
 
             var certificateData = JsonConvert.DeserializeObject<CertificateData>(certificate.CertificateData);
 
-            if (submittingContact.OrganisationId == searchingContact.OrganisationId)
+            if (submittingContact != null && searchingContact != null && submittingContact.OrganisationId == searchingContact.OrganisationId)
             {
                 searchResult.ShowExtraInfo = true;
                 searchResult.OverallGrade = certificateData.OverallGrade;


### PR DESCRIPTION
To prevent Index out of bounds when the previous FAIl was created by API.