### PR TITLE
[CON-3918] BUG: Removed AddHttpClient registration of IRoatpApiClient…

### DIFF
--- a/src/SFA.DAS.AssessorService.Application.Api/Controllers/OrganisationSearchController.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/Controllers/OrganisationSearchController.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.AssessorService.Application.Api.Controllers
     public class OrganisationSearchController : Controller
     {
         private readonly ILogger<OrganisationSearchController> _logger;
-        private readonly RoatpApiClient _roatpApiClient;
+        private readonly IRoatpApiClient _roatpApiClient;
         private readonly ReferenceDataApiClient _referenceDataApiClient;
         private readonly CompaniesHouseApiClient _companiesHouseApiClient;
         private readonly CharityCommissionApiClient _charityCommissionApiClient;

--- a/src/SFA.DAS.AssessorService.Application.Api/StartupConfiguration/Startup.cs
+++ b/src/SFA.DAS.AssessorService.Application.Api/StartupConfiguration/Startup.cs
@@ -164,7 +164,7 @@ namespace SFA.DAS.AssessorService.Application.Api.StartupConfiguration
                     })
                     .SetHandlerLifetime(TimeSpan.FromMinutes(5));
 
-                services.AddHttpClient<IRoatpApiClient, RoatpApiClient>("RoatpApiClient", config =>
+                services.AddHttpClient<RoatpApiClient>("RoatpApiClient", config =>
                     {
                         config.BaseAddress = new Uri(Configuration.RoatpApiAuthentication.ApiBaseAddress); //  "https://at-providers-api.apprenticeships.education.gov.uk"
                         config.DefaultRequestHeaders.Add("Accept", "Application/json");


### PR DESCRIPTION
… as this is being duplicated during the structuremap container registration UseDefaultConventions().

Not a simple change to move around the ordering of the code and would potentially break the other calls to AddHttpClient as they would need to be seperately registered to interfaces also.

Now the _.WithDefaultConventions handles For<IRoatpApiClient, RoatpApiClient> and the call to AddHttpClient is responsible for injectng the appropiate HttpClient with correct config to the concrete RoatpApiClient.