### PR TITLE
SV-1259 improve populate learner redone

### DIFF
--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/PopulateLearner.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/PopulateLearner.sql
@@ -1,20 +1,21 @@
 ﻿-- Populates Learner by merging ApprovalsExtract with ILRs
+
 CREATE PROCEDURE [dbo].[PopulateLearner]
 AS
-BEGIN
+BEGIN 
    DECLARE 
 		@expiretime int = -12,  -- months to allow for overrun after planned/estimated end date before EPA should have been done
-		@lapsedtime int = -14;  -- months to allow for delay in submitting ILRs (should not be greater than 14)
+		@lapsedtime int = -14,  -- months to allow for delay in submitting ILRs (should not be greater than 14)
+		@overlaptime int = -30; -- days to allow for an overlap on ILR submisisons and Approvals changes
 		
    BEGIN TRANSACTION;
    SAVE TRANSACTION Updatelearner;
    
    BEGIN TRY
-   
-		-- clear learner data in a transaction 
-		DELETE FROM Learner WHERE Id IS NOT NULL;
-		
-		-- re-populate
+  
+		----------------------------------------------------------------------------------------------------------------------
+		----------------------------------------------------------------------------------------------------------------------
+		-- Populate Learner with latest changes from ILR or Approvals
 		----------------------------------------------------------------------------------------------------------------------
 		----------------------------------------------------------------------------------------------------------------------
 		WITH LatestVersions
@@ -29,6 +30,18 @@ BEGIN
 		)
 		,
 		----------------------------------------------------------------------------------------------------------------------
+		LearnerMods
+		AS
+		(
+		-- find the recently changed learners from either data source, with an overlap to allow for missed ILR submissions
+			SELECT Uln, StdCode FROM Ilrs 
+			WHERE ISNULL(UpdatedAt,CreatedAt) >= (SELECT ISNULL(DATEADD(day,@overlaptime,MAX(LatestIlrs)), '01-Jan-2017') FROM Learner)
+			UNION
+			SELECT Uln, TrainingCode FROM ApprovalsExtract 
+			WHERE ISNULL(UpdatedOn,CreatedOn) >= (SELECT ISNULL(DATEADD(day,@overlaptime,MAX(LatestApprovals)), '01-Jan-2017') FROM Learner)
+		)
+		----------------------------------------------------------------------------------------------------------------------
+		,
 		il1
 		AS (
 			SELECT *
@@ -39,14 +52,16 @@ BEGIN
 			FROM (
 				SELECT Ilrs.*, ISNULL(UpdatedAt,CreatedAt) LastUpdated
 					  -- if could only be version 1.0 then this can be assumed as confirmed
-					  ,CASE WHEN lv1.Version = '1.0' THEN '1.0' ELSE [dbo].[GetVersionFromLarsCode](LearnStartDate,StdCode) END Version
+					  ,CASE WHEN lv1.Version = '1.0' THEN '1.0' ELSE [dbo].[GetVersionFromLarsCode](LearnStartDate,Ilrs.StdCode) END Version
 					  ,CASE WHEN lv1.Version = '1.0' THEN 1 ELSE 0 END VersionConfirmed
 					  -- use StandardUId for version 1.0 (if appropriate) or estimate based on startdate when unknown
-					  ,CASE WHEN lv1.Version = '1.0' THEN lv1.StandardUId ELSE [dbo].[GetStandardUidFromLarsCode](LearnStartDate,StdCode) END StandardUId
+					  ,CASE WHEN lv1.Version = '1.0' THEN lv1.StandardUId ELSE [dbo].[GetStandardUidFromLarsCode](LearnStartDate,Ilrs.StdCode) END StandardUId
 					  ,lv1.StandardReference
 					  ,lv1.Title StandardName
 					  ,CASE WHEN PlannedEndDate > GETDATE() THEN EOMONTH(PlannedEndDate) ELSE EOMONTH(DATEADD(month, lv1.Duration, LearnStartDate)) END EstimatedEndDate
-			   FROM Ilrs JOIN LatestVersions lv1 on lv1.LarsCode = Ilrs.StdCode
+			   FROM Ilrs 
+			   JOIN LatestVersions lv1 on lv1.LarsCode = Ilrs.StdCode
+			   JOIN LearnerMods ls1 on ls1.Uln = Ilrs.Uln AND ls1.StdCode = Ilrs.StdCode  -- only include changed learners
 			) il2
 		)
 		 ,
@@ -102,7 +117,7 @@ BEGIN
 					SELECT ApprenticeshipId
 					  ,FirstName
 					  ,LastName
-					  ,ULN
+					  ,ap1.ULN
 					  ,TrainingCode
 					  ,TrainingCourseVersion
 					  ,TrainingCourseVersionConfirmed
@@ -123,11 +138,12 @@ BEGIN
 							WHEN PauseDate IS NOT NULL THEN 6
 							WHEN CompletionDate IS NOT NULL THEN 2 
 							ELSE (CASE WHEN PaymentStatus = 1 THEN 1 ELSE 0 END) END CompletionStatus 
-					  ,LAG(UKPRN, 1,0) OVER (PARTITION BY ULN, TrainingCode ORDER BY CreatedOn ) AS UKPRN_1
-					  ,LAG(StartDate, 1,0) OVER (PARTITION BY ULN, TrainingCode ORDER BY CreatedOn ) AS StartDate_1
-					  ,LAG(EndDate, 1,0) OVER (PARTITION BY ULN, TrainingCode ORDER BY CreatedOn ) AS EndDate_1
-					  ,LAG(CONVERT(datetime,StopDate), 1,0) OVER (PARTITION BY ULN, TrainingCode ORDER BY CreatedOn ) AS StopDate_1
+					  ,LAG(UKPRN, 1,0) OVER (PARTITION BY ap1.ULN, TrainingCode ORDER BY CreatedOn ) AS UKPRN_1
+					  ,LAG(StartDate, 1,0) OVER (PARTITION BY ap1.ULN, TrainingCode ORDER BY CreatedOn ) AS StartDate_1
+					  ,LAG(EndDate, 1,0) OVER (PARTITION BY ap1.ULN, TrainingCode ORDER BY CreatedOn ) AS EndDate_1
+					  ,LAG(CONVERT(datetime,StopDate), 1,0) OVER (PARTITION BY ap1.ULN, TrainingCode ORDER BY CreatedOn ) AS StopDate_1
 					FROM ApprovalsExtract ap1
+ 				    JOIN LearnerMods ls1 on ls1.Uln = ap1.Uln AND ls1.StdCode = ap1.TrainingCode  -- only include changed learners
 					WHERE 1=1
 					  AND NOT (StopDate IS NOT NULL AND EOMONTH(StopDate) = EOMONTH(StartDate) AND PaymentStatus = 3) -- cancelled, not started, effectively deleted
 				) ab2
@@ -136,10 +152,10 @@ BEGIN
 		)
 		----------------------------------------------------------------------------------------------------------------------
 		----------------------------------------------------------------------------------------------------------------------
-		INSERT INTO Learner (Id, Uln, GivenNames, FamilyName, UkPrn, StdCode, LearnStartDate, EpaOrgId, FundingModel, ApprenticeshipId, 
-		Source, LearnRefNumber, CompletionStatus, PlannedEndDate, DelLocPostCode, LearnActEndDate, WithdrawReason, 
-		Outcome, AchDate, OutGrade, Version, VersionConfirmed, CourseOption, StandardUId, StandardReference, StandardName, LastUpdated, EstimatedEndDate, ApprovalsStopDate, ApprovalsPauseDate, ApprovalsCompletionDate, ApprovalsPaymentStatus )
 
+		MERGE INTO Learner lm1
+		USING 
+		(
 		----------------------------------------------------------------------------------------------------------------------
 		-- using ILR with Approvals Extract for some key fields that can be updated in Approvals 
 		----------------------------------------------------------------------------------------------------------------------
@@ -179,7 +195,9 @@ BEGIN
 				ax1.StopDate ApprovalsStopDate,
 				ax1.PauseDate ApprovalsPauseDate,
 				ax1.CompletionDate ApprovalsCompletionDate,
-				ax1.PaymentStatus ApprovalsPaymentStatus
+				ax1.PaymentStatus ApprovalsPaymentStatus,
+				il1.LastUpdated LatestIlrs,
+				ax1.LastUpdated LatestApprovals
 		  FROM ax1 
 		  JOIN il1 ON ax1.ULN = il1.ULN  AND il1.StdCode = ax1.TrainingCode	
 		  WHERE il1.FundingModel != 99
@@ -221,13 +239,72 @@ BEGIN
 				null ApprovalsStopDate,
 				null ApprovalsPauseDate,
 				null ApprovalsCompletionDate,
-				null ApprovalsPaymentStatus 
+				null ApprovalsPaymentStatus, 
+				il1.LastUpdated LatestIlrs,
+				null LatestApprovals
 		  FROM il1 
 		  LEFT JOIN ax1 ON ax1.ULN = il1.ULN  AND il1.StdCode = ax1.TrainingCode
 		  WHERE (il1.FundingModel = 99 OR ax1.ULN IS NULL)
 			AND Lapsed = 0 
 			AND Expired = 0
-		  
+		) upd
+		ON (lm1.uln = upd.uln AND lm1.StdCode = upd.StdCode)
+
+		WHEN MATCHED THEN UPDATE
+		SET 
+			 lm1.GivenNames = upd.GivenNames,
+			 lm1.FamilyName = upd.FamilyName,
+			 lm1.UkPrn = upd.UkPrn,
+			 lm1.LearnStartDate = upd.LearnStartDate,
+			 lm1.EpaOrgId = upd.EpaOrgId,
+			 lm1.FundingModel = upd.FundingModel,
+			 lm1.ApprenticeshipId = upd.ApprenticeshipId,
+			 lm1.Source = upd.Source,
+			 lm1.LearnRefNumber = upd.LearnRefNumber,
+			 lm1.CompletionStatus = upd.CompletionStatus,
+			 lm1.PlannedEndDate = upd.PlannedEndDate,
+			 lm1.DelLocPostCode = upd.DelLocPostCode,
+			 lm1.LearnActEndDate = upd.LearnActEndDate,
+			 lm1.WithdrawReason = upd.WithdrawReason,
+			 lm1.Outcome = upd.Outcome,
+			 lm1.AchDate = upd.AchDate,
+			 lm1.OutGrade = upd.OutGrade,
+			 lm1.Version = upd.Version,
+			 lm1.VersionConfirmed = upd.VersionConfirmed,
+			 lm1.CourseOption = upd.CourseOption,
+			 lm1.StandardUId = upd.StandardUId,
+			 lm1.StandardReference = upd.StandardReference,
+			 lm1.StandardName = upd.StandardName,
+			 lm1.LastUpdated = upd.LastUpdated,
+			 lm1.EstimatedEndDate = upd.EstimatedEndDate,
+			 lm1.ApprovalsStopDate = upd.ApprovalsStopDate,
+			 lm1.ApprovalsPauseDate = upd.ApprovalsPauseDate,
+			 lm1.ApprovalsCompletionDate = upd.ApprovalsCompletionDate,
+			 lm1.LatestIlrs = upd.LatestIlrs,
+			 lm1.LatestApprovals = upd.LatestApprovals
+
+		WHEN NOT MATCHED THEN
+		INSERT (Id, Uln, GivenNames, FamilyName, UkPrn, StdCode, LearnStartDate, EpaOrgId, FundingModel, ApprenticeshipId, 
+				Source, LearnRefNumber, CompletionStatus, PlannedEndDate, DelLocPostCode, LearnActEndDate, WithdrawReason, 
+				Outcome, AchDate, OutGrade, Version, VersionConfirmed, CourseOption, StandardUId, StandardReference, StandardName, 
+				LastUpdated, EstimatedEndDate, ApprovalsStopDate, ApprovalsPauseDate, ApprovalsCompletionDate, ApprovalsPaymentStatus,
+				LatestIlrs, LatestApprovals)
+		VALUES (upd.Id, upd.Uln, upd.GivenNames, upd.FamilyName, upd.UkPrn, upd.StdCode, upd.LearnStartDate, upd.EpaOrgId, upd.FundingModel, upd.ApprenticeshipId,
+				upd.Source, upd.LearnRefNumber, upd.CompletionStatus, upd.PlannedEndDate, upd.DelLocPostCode, upd.LearnActEndDate, upd.WithdrawReason,
+				upd.Outcome, upd.AchDate, upd.OutGrade, upd.Version, upd.VersionConfirmed, upd.CourseOption, upd.StandardUId, upd.StandardReference, upd.StandardName,
+				upd.LastUpdated, upd.EstimatedEndDate, upd.ApprovalsStopDate, upd.ApprovalsPauseDate, upd.ApprovalsCompletionDate, upd.ApprovalsPaymentStatus,
+				upd.LatestIlrs, upd.LatestApprovals)
+;
+
+		-- Remove Lapased or Expired learner records
+		DELETE FROM Learner
+		WHERE
+		-- check for ILR records that are for Apprenticeships that have significantly overrun the end date	
+			EstimatedEndDate < dateadd(month, @expiretime, GETDATE())  -- Expired
+		OR
+		-- check for "Continuing" ILR records that have not been updated for a long time - they should be updated every month.
+		   (CompletionStatus = 1 AND LastUpdated < DATEADD(month, @lapsedtime, GETDATE())) -- Lapsed
+
    
 		COMMIT TRANSACTION 
 	END TRY

--- a/src/SFA.DAS.AssessorService.Database/Tables/ApprovalsExtract.sql
+++ b/src/SFA.DAS.AssessorService.Database/Tables/ApprovalsExtract.sql
@@ -18,14 +18,19 @@
     [CompletionDate] DATE NULL,
     [UKPRN] INT NULL,
     [LearnRefNumber] NVARCHAR(50) NULL,
-    [PaymentStatus] SMALLINT NULL
+    [PaymentStatus] SMALLINT NULL,
+    [LastUpdated] AS ISNULL([UpdatedOn],[CreatedOn])
     
 )
 GO
 
-CREATE INDEX [IX_ApprovalsExtract_Uln_StandardCode] ON [ApprovalsExtract] ([Uln], [TrainingCode]) 
+
+CREATE INDEX [IX_ApprovalsExtract_TrainingCode_ULN] ON [ApprovalsExtract] ([TrainingCode], [Uln], [StartDate], [PaymentStatus] ,[StopDate]) 
+INCLUDE ([ApprenticeshipId] ,[FirstName] ,[LastName] ,[TrainingCourseVersion] ,[TrainingCourseVersionConfirmed] ,[TrainingCourseOption] ,
+         [StandardUId] ,[EndDate] ,[CreatedOn] ,[UpdatedOn] ,[PauseDate] ,[CompletionDate] ,[UKPRN] ,[LearnRefNumber] ,[LastUpdated])
+      
 GO
 
-CREATE INDEX [IX_ApprovalsExtract_StandardCode_ULN] ON [ApprovalsExtract] ([TrainingCode], [Uln])
-INCLUDE ([StartDate],[CreatedOn],[UpdatedOn],[CompletionDate],[EndDate],[StopDate],[PauseDate],[PaymentStatus])
+
+CREATE NONCLUSTERED INDEX [IX_ApprovalsExtract_LastUpdated] ON [ApprovalsExtract] ([LastUpdated]) INCLUDE ([TrainingCode], [Uln] )
 GO

--- a/src/SFA.DAS.AssessorService.Database/Tables/Ilrs.sql
+++ b/src/SFA.DAS.AssessorService.Database/Tables/Ilrs.sql
@@ -23,7 +23,8 @@
 	[WithdrawReason] [int] NULL,
 	[Outcome] [int] NULL,
 	[AchDate] [datetime] NULL,
-	[OutGrade] [nvarchar](50) NULL	
+	[OutGrade] [nvarchar](50) NULL,
+    [LastUpdated] AS ISNULL([UpdatedAt],[CreatedAt])
 )
 
 GO
@@ -38,4 +39,7 @@ CREATE NONCLUSTERED INDEX [IX_Ilrs_EpaOrgId_StdCode_Uln] ON [Ilrs] ([EpaOrgId], 
 GO
 
 CREATE NONCLUSTERED INDEX [IX_Ilrs_CompletionStatus_StdCode] ON [Ilrs] ([CompletionStatus], [StdCode]) INCLUDE ([DelLocPostCode], [LearnStartDate], [PlannedEndDate], [Uln])
+GO
+
+CREATE NONCLUSTERED INDEX [IX_Ilrs_LastUpdated] ON [Ilrs] ([LastUpdated]) INCLUDE ([Uln], [StdCode]) 
 GO

--- a/src/SFA.DAS.AssessorService.Database/Tables/Learner.sql
+++ b/src/SFA.DAS.AssessorService.Database/Tables/Learner.sql
@@ -31,7 +31,9 @@ CREATE TABLE [dbo].[Learner]
     [ApprovalsStopDate] DATE NULL,
     [ApprovalsPauseDate] DATE NULL,
     [ApprovalsCompletionDate] DATE NULL,
-    [ApprovalsPaymentStatus] SMALLINT NULL
+    [ApprovalsPaymentStatus] SMALLINT NULL,
+    [LatestIlrs] DATETIME NULL,
+    [LatestApprovals] DATETIME NULL
     
 )
 GO
@@ -46,4 +48,7 @@ CREATE NONCLUSTERED INDEX [IX_Learner_EpaOrgId_StdCode_Uln] ON [Learner] ([EpaOr
 GO
 
 CREATE NONCLUSTERED INDEX [IX_Learner_CompletionStatus_StdCode] ON [Learner] ([CompletionStatus], [StdCode]) INCLUDE ([DelLocPostCode], [LearnStartDate], [PlannedEndDate], [Uln])
+GO
+
+CREATE NONCLUSTERED INDEX [IX_Learner_Updated] ON [Learner] ([Uln], [StdCode], [LatestIlrs], [LatestApprovals])
 GO

--- a/src/SFA.DAS.AssessorService.Database/Tables/Learner.sql
+++ b/src/SFA.DAS.AssessorService.Database/Tables/Learner.sql
@@ -41,14 +41,14 @@ GO
 CREATE UNIQUE INDEX [IXU_Learner_Uln_StdCode] ON [Learner] ([Uln], [StdCode]) INCLUDE ([FamilyName])
 GO
 
-CREATE NONCLUSTERED INDEX [IX_Learner_EpaOrgId_StdCode_CompletionStatus] ON [Learner] ([EpaOrgId], [StdCode], [CompletionStatus]) INCLUDE ([LearnStartDate], [PlannedEndDate], [Uln])
+CREATE NONCLUSTERED INDEX [IX_Learner_EpaOrgId_StdCode_Uln_CompletionStatus] ON [Learner] ( [StdCode], [Uln], [CompletionStatus], [EpaOrgId]) INCLUDE ([DelLocPostCode], [LearnStartDate], [PlannedEndDate])
 GO
 
-CREATE NONCLUSTERED INDEX [IX_Learner_EpaOrgId_StdCode_Uln] ON [Learner] ([EpaOrgId], [StdCode], [Uln]) INCLUDE ([LearnStartDate], [PlannedEndDate], [CompletionStatus])
+CREATE NONCLUSTERED INDEX [IX_Learner_LatestIlrs] ON [Learner] ([LatestIlrs], [Uln], [StdCode]) 
 GO
 
-CREATE NONCLUSTERED INDEX [IX_Learner_CompletionStatus_StdCode] ON [Learner] ([CompletionStatus], [StdCode]) INCLUDE ([DelLocPostCode], [LearnStartDate], [PlannedEndDate], [Uln])
+CREATE NONCLUSTERED INDEX [IX_Learner_LatestApprovals] ON [Learner] ([LatestApprovals], [Uln], [StdCode]) 
 GO
 
-CREATE NONCLUSTERED INDEX [IX_Learner_Updated] ON [Learner] ([Uln], [StdCode], [LatestIlrs], [LatestApprovals])
+CREATE NONCLUSTERED INDEX [IX_Learner_Source] ON [Learner] ([Source], [EstimatedEndDate], [CompletionStatus], [LastUpdated]) 
 GO


### PR DESCRIPTION
Revised approach, without the TRANSACTIOn in PopulateLearner, and with added computed LastUpdated columns on Approvals Extracrt and Ilrs, to allow only recently changed learners to be re-populated in Learner table.