### PR TITLE
QF-592 Allow PopulateLearner Stored Procedure to be parameterised 

### DIFF
--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/PopulateLearner.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/PopulateLearner.sql
@@ -1,11 +1,10 @@
 ﻿-- Populates Learner by merging ApprovalsExtract with ILRs
-
 CREATE PROCEDURE [dbo].[PopulateLearner]
+		@overlaptimeIlr int = -15, -- days to allow for an overlap on ILR submissions changes
+		@overlaptimeApx int = -15  -- days to allow for an overlap on Approvals changes
 AS
 BEGIN 
    DECLARE 
-		@overlaptimeIlr int = -15, -- days to allow for an overlap on ILR submissions changes
-		@overlaptimeApx int = -15, -- days to allow for an overlap on Approvals changes
 		@upserted int = 0;
 		
 	BEGIN 


### PR DESCRIPTION
This allows the time periods for PopulateLearner to be parameters, to override the default values.