### PR TITLE
Qf 588 move exclusions filter

### DIFF
--- a/src/SFA.DAS.AssessorService.Database/PostDeploymentScripts/LookupData/StaffReportsInsertOrUpdate.sql
+++ b/src/SFA.DAS.AssessorService.Database/PostDeploymentScripts/LookupData/StaffReportsInsertOrUpdate.sql
@@ -70,6 +70,13 @@ INSERT #StaffReports VALUES (N'4ec6aa79-75ac-4dfe-b277-e2fac7096bda', N'Batch', 
 INSERT #StaffReports VALUES (N'd8d8aa09-74b1-4dc4-bbc6-f0b6e71a60cc', N'EPAO', N'StaffReports_ByEpao', CAST(N'2018-10-24T13:51:17.8333333' AS DateTime2), NULL, NULL, 5, N'ViewOnScreen', NULL)
 INSERT #StaffReports VALUES (N'ec0b30aa-1a6b-4de4-bebd-fb9aaf1a3331', N'Weekly summary', N'StaffReports_WeeklySummary', CAST(N'2018-10-24T13:51:17.8033333' AS DateTime2), NULL, NULL, 3, N'ViewOnScreen', NULL)
 INSERT #StaffReports VALUES (N'db48b407-6160-426a-9a45-693970d47edc', N'Missing certificate data', N'StaffReports_MissingCertificateData', CAST(N'2021-03-31T00:00:00.0000000' AS DateTime2), NULL, NULL, 15, N'ViewOnScreen', NULL)
+INSERT #StaffReports VALUES (N'3800291d-6209-4e65-be4d-e8d390997de8', N'Active Apprentices by Standard', N'', CAST(N'2022-08-22 00:00:00.0000000' AS DateTime2), NULL, NULL, 16, N'Download', N'{"Name":"List Of Active Apprentices by Standard","Worksheets": [
+	  {
+	  "worksheet": "List Of Active Apprentices",
+	  "order": 1,
+	  "StoredProcedure": "StaffReports_List_Approved_Standards"
+	  }
+	]}')
 
 MERGE [StaffReports] [Target] USING #StaffReports [Source]
 ON ([Source].[Id] = [Target].[Id])

--- a/src/SFA.DAS.AssessorService.Database/SFA.DAS.AssessorService.Database.sqlproj
+++ b/src/SFA.DAS.AssessorService.Database/SFA.DAS.AssessorService.Database.sqlproj
@@ -184,6 +184,7 @@
     <Build Include="Tables\MergeApply.sql" />
     <Build Include="StoredProcedures\UndoOrganisationMerge.sql" />
     <None Include="PostDeploymentScripts\SV-889-UpdateApplyViaOptInStatus.sql" />
+    <Build Include="StoredProcedures\StaffReports_List_Approved_Standards.sql" />
   </ItemGroup>
   <ItemGroup>
     <RefactorLog Include="SFA.DAS.AssessorService.Database.refactorlog" />

--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/OppFinder_List_Approved_Standards.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/OppFinder_List_Approved_Standards.sql
@@ -1,11 +1,11 @@
 ﻿CREATE PROCEDURE [dbo].[OppFinder_List_Approved_Standards]
-	 @SearchTerm AS NVARCHAR(100),
-	 @SectorFilters AS NVARCHAR(MAX),
-	 @LevelFilters AS NVARCHAR(MAX),
-	 @SortColumn AS NVARCHAR(20),
-	 @SortAscending AS INT,
-     @PageSize AS INT,
-     @PageIndex AS INT,
+	 @SearchTerm AS NVARCHAR(100) = '',
+	 @SectorFilters AS NVARCHAR(MAX) = '',
+	 @LevelFilters AS NVARCHAR(MAX) = '',
+	 @SortColumn AS NVARCHAR(20) = 'StandardName',
+	 @SortAscending AS INT = 1,
+     @PageSize AS INT = 50,
+     @PageIndex AS INT = 1,
      @TotalCount AS INT OUTPUT,
 	 @ApplyExclusions AS INT = 1  -- set to 1 to apply exclusions or 0 to ignore 
 AS

--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/OppFinder_Update_StandardSummary.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/OppFinder_Update_StandardSummary.sql
@@ -18,16 +18,6 @@ DECLARE @Error_Code INT = 0
 BEGIN
 	BEGIN TRANSACTION T1;
 	
-	-- there are some specifically excluded Standards
-	DECLARE @Exclusions TABLE
-	(
-		StandardName nvarchar(500),
-		StandardReference nvarchar(10)
-	) 
-	
-	INSERT INTO @Exclusions(StandardName, StandardReference)
-	EXEC OppFinder_Exclusions 
-
 	DECLARE @StandardsCore TABLE
 	(
 		 StandardCode INT NULL, 
@@ -62,13 +52,11 @@ BEGIN
 		   -- When LARS set LastDateStarts to EffectiveFrom Date this is because there is no EPAO for this standard, so we want EPAOs to see the Opportunity!
 		   AND (LastDateStarts IS NULL OR LastDateStarts = EffectiveFrom)
 	) stv 
-	LEFT JOIN @Exclusions ex1 ON ex1.StandardReference = stv.StandardReference
-	WHERE RowNumber = 1
-	  AND ex1.StandardName IS NULL;
+	WHERE RowNumber = 1;
 
 	BEGIN TRY;
 	
-	DELETE FROM StandardSummary WHERE 1=1;
+	TRUNCATE TABLE StandardSummary;
 	
 	INSERT INTO StandardSummary
 	-- combine results FROM 4 subqueries
@@ -168,7 +156,7 @@ BEGIN
 	
 	
 	-- populate the StandardVersionSummary table
-	DELETE FROM StandardVersionSummary WHERE 1=1;
+	TRUNCATE TABLE StandardVersionSummary;
 	
 	INSERT INTO StandardVersionSummary
 	(StandardCode, StandardReference, Version, ActiveApprentices, CompletedAssessments, EndPointAssessors, UpdatedAt)

--- a/src/SFA.DAS.AssessorService.Database/StoredProcedures/StaffReports_List_Approved_Standards.sql
+++ b/src/SFA.DAS.AssessorService.Database/StoredProcedures/StaffReports_List_Approved_Standards.sql
@@ -1,0 +1,19 @@
+﻿CREATE PROCEDURE [dbo].[StaffReports_List_Approved_Standards]
+AS
+BEGIN
+DECLARE	@return_value int,
+		@TotalCount int
+
+EXEC	@return_value = [dbo].[OppFinder_List_Approved_Standards]
+		@PageSize = 5000,
+		@PageIndex = 1,
+		@SearchTerm = '',
+		@SectorFilters = '',
+		@LevelFilters = '',
+		@SortColumn = 'ActiveApprentices',
+		@SortAscending = 0,
+		@TotalCount = @TotalCount OUTPUT,
+		@ApplyExclusions = 0
+
+RETURN @return_value
+END


### PR DESCRIPTION
This change allows the **Active Apprentices by Standard with EPAOs data** to be downloaded as a report without the Exclusions that are applied to the EPAO Opportunity public view of the data. Requires that the StandardSummary data is not filtered for pre-defined Exclusions, but instead the filtering is applied on displaying the standards data in EPAO Opprtunity Finder. New staff report added to Admin service to allow the data to be downloaded without any Exclusions.