### PR TITLE
QF-1202 Prevent XSS vulnerability in address preview by encoding HTML

### DIFF
--- a/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/SFA.DAS.AssessorService.Application.Api.External.UnitTests.csproj
+++ b/src/SFA.DAS.AssessorService.Application.Api.External.UnitTests/SFA.DAS.AssessorService.Application.Api.External.UnitTests.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.106" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.169" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.AssessorService.Application.Api.External/SFA.DAS.AssessorService.Application.Api.External.csproj
+++ b/src/SFA.DAS.AssessorService.Application.Api.External/SFA.DAS.AssessorService.Application.Api.External.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.NLogTarget" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.4" />
-    <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
+    <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.2.1" />
     <PackageReference Include="StructureMap" Version="4.6.1" />
     <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="1.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />

--- a/src/SFA.DAS.AssessorService.Application.Api.UnitTests/SFA.DAS.AssessorService.Application.Api.UnitTests.csproj
+++ b/src/SFA.DAS.AssessorService.Application.Api.UnitTests/SFA.DAS.AssessorService.Application.Api.UnitTests.csproj
@@ -8,15 +8,15 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.106" />
+    <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.169" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.AssessorService.Api.Types\SFA.DAS.AssessorService.Api.Types.csproj" />

--- a/src/SFA.DAS.AssessorService.Application.Api/SFA.DAS.AssessorService.Application.Api.csproj
+++ b/src/SFA.DAS.AssessorService.Application.Api/SFA.DAS.AssessorService.Application.Api.csproj
@@ -28,8 +28,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.0" />
-
-	  <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.Security" Version="4.10.0" />
   </ItemGroup>

--- a/src/SFA.DAS.AssessorService.Application.Api/SFA.DAS.AssessorService.Application.Api.csproj
+++ b/src/SFA.DAS.AssessorService.Application.Api/SFA.DAS.AssessorService.Application.Api.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.0" />
-    <PackageReference Include="System.ServiceModel.Federation" Version="4.10.*" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
+
+	  <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.Security" Version="4.10.0" />
   </ItemGroup>

--- a/src/SFA.DAS.AssessorService.Application.IntegrationTests/SFA.DAS.AssessorService.Application.Api.IntegrationTests.csproj
+++ b/src/SFA.DAS.AssessorService.Application.IntegrationTests/SFA.DAS.AssessorService.Application.Api.IntegrationTests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.169" />
   </ItemGroup>
 

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/SFA.DAS.AssessorService.Application.UnitTests.csproj
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/SFA.DAS.AssessorService.Application.UnitTests.csproj
@@ -10,15 +10,15 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.106" />
+    <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.169" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.AssessorService.Api.Types\SFA.DAS.AssessorService.Api.Types.csproj" />

--- a/src/SFA.DAS.AssessorService.Data.IntegrationTests/SFA.DAS.AssessorService.Data.IntegrationTests.csproj
+++ b/src/SFA.DAS.AssessorService.Data.IntegrationTests/SFA.DAS.AssessorService.Data.IntegrationTests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SFA.DAS.AssessorService.Data.UnitTests/SFA.DAS.AssessorService.Data.UnitTests.csproj
+++ b/src/SFA.DAS.AssessorService.Data.UnitTests/SFA.DAS.AssessorService.Data.UnitTests.csproj
@@ -5,12 +5,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.13" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="6.0.1.4" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SFA.DAS.AssessorService.Domain.UnitTests/SFA.DAS.AssessorService.Domain.UnitTests.csproj
+++ b/src/SFA.DAS.AssessorService.Domain.UnitTests/SFA.DAS.AssessorService.Domain.UnitTests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SFA.DAS.AssessorService.Web.UnitTests/SFA.DAS.AssessorService.Web.UnitTests.csproj
+++ b/src/SFA.DAS.AssessorService.Web.UnitTests/SFA.DAS.AssessorService.Web.UnitTests.csproj
@@ -5,11 +5,11 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SFA.DAS.AssessorService.Web/wwwroot/javascripts/address-lookup-service.js
+++ b/src/SFA.DAS.AssessorService.Web/wwwroot/javascripts/address-lookup-service.js
@@ -186,13 +186,17 @@
         }
     }
 
+    function encodeHtml(possiblyUnsafeString) { 
+        return $('<div>').text(possiblyUnsafeString).html();
+    }
+
     function restorePreviousAddress() {
         var hasPreviousValues = false;
         var showAddressSelectionPanel = !$(".js-address-panel").hasClass("js-address-panel-never-show");
 
         $.each(addressFields, function (index, value) {
             if ($(index).length && !($(index).val().length === 0)) {
-                $(".js-address-panel ul").append("<li>" + $(index).val() + "</li>");
+                $(".js-address-panel ul").append("<li>" + encodeHtml($(index).val()) + "</li>");
 
                 if ($("#postcode-search").length > 0 && $("#postcode-search").val().length > 0) {
                     $("#postcode-search").val($("#postcode-search").val() + ', ');


### PR DESCRIPTION
- Encode HTML in the Address fields before showing it in the preview 
- Removed the System.ServiceModel.Federation floating package version that was added by Visual Studio while upgrading the Connected Services during the .NET 6 package. This version mismatch was preventing the master branch from building
- Updated internal SFA.DAS package references to the latest versions
- Updated package references related to unit testing