### PR TITLE
FAI-760 FAI-987 New Email template for User Login SignUp

### DIFF
--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/UserManagement/WhenHandlingApproveContact.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/UserManagement/WhenHandlingApproveContact.cs
@@ -1,0 +1,52 @@
+﻿using AutoFixture.NUnit3;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models;
+using SFA.DAS.AssessorService.Api.Types.Models.UserManagement;
+using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Application.Handlers.UserManagement;
+using SFA.DAS.AssessorService.Application.Interfaces;
+using SFA.DAS.AssessorService.Domain.Entities;
+using SFA.DAS.AssessorService.Settings;
+using SFA.DAS.Testing.AutoFixture;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.UserManagement
+{
+    public class WhenHandlingApproveContact
+    {
+        [Test, MoqAutoData]
+        public async Task Then_ApproveConfirmation_Email_Sent(
+            [Frozen] Mock<IContactQueryRepository> contactQueryRepository,
+            [Frozen] Mock<IContactRepository> contactRepository,
+            [Frozen] Mock<IOrganisationQueryRepository> organisationQueryRepository,
+            [Frozen] Mock<IEmailApiClient> emailApiClient,
+            [Frozen] Mock<IApiConfiguration> apiConfiguration,
+            EmailTemplatesConfig emailTemplatesConfig,
+            ApproveContactRequest request,
+            ApproveContactHandler sut)
+        {
+            //Arrange
+            var contact = new Contact { Id = Guid.NewGuid(), OrganisationId = Guid.NewGuid() };
+
+            contactQueryRepository.Setup(s => s.GetContactById(request.ContactId)).ReturnsAsync(contact);
+            organisationQueryRepository.Setup(s => s.Get(contact.OrganisationId.Value)).ReturnsAsync(new Organisation());
+
+            contactRepository.Setup(x => x.UpdateContactWithOrganisationData(It.IsAny<UpdateContactWithOrgAndStausRequest>())).ReturnsAsync(contact);
+            emailApiClient.Setup(x => x.SendEmailWithTemplate(It.IsAny<SendEmailRequest>()))
+                .Returns(Task.CompletedTask);
+            
+            apiConfiguration.Setup(x => x.EmailTemplatesConfig).Returns(emailTemplatesConfig);
+            apiConfiguration.Setup(x => x.ServiceLink).Returns(It.IsAny<string>());
+
+            //Act
+            await sut.Handle(request, new CancellationToken());
+
+            //Assert
+            emailApiClient.Verify(x => x.SendEmailWithTemplate(It.IsAny<SendEmailRequest>()), Times.Once);
+        }
+    }
+}
+

--- a/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/UserManagement/WhenHandlingInviteContactToOrganisation.cs
+++ b/src/SFA.DAS.AssessorService.Application.UnitTests/Handlers/UserManagement/WhenHandlingInviteContactToOrganisation.cs
@@ -1,0 +1,73 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.AssessorService.Api.Types.Models;
+using SFA.DAS.AssessorService.Api.Types.Models.UserManagement;
+using SFA.DAS.AssessorService.Application.Api.Client.Clients;
+using SFA.DAS.AssessorService.Application.Handlers.UserManagement;
+using SFA.DAS.AssessorService.Application.Interfaces;
+using SFA.DAS.AssessorService.Domain.Entities;
+using SFA.DAS.AssessorService.Settings;
+using SFA.DAS.Testing.AutoFixture;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.AssessorService.Application.UnitTests.Handlers.UserManagement
+{
+    public class WhenHandlingInviteContactToOrganisation
+    {
+        [Test, MoqAutoData]
+        public async Task Then_Returns_ErrorResponse_WhenContactAlreadyExist(
+            [Frozen] Mock<IContactQueryRepository> contactQueryRepository,
+            [Frozen] Mock<IEmailApiClient> emailApiClient,
+            InviteContactToOrganisationRequest request,
+            InviteContactToOrganisationHandler sut)
+        {
+            //Arrange
+            var contact = new Contact { Id = Guid.NewGuid() };
+            contactQueryRepository.Setup(s => s.GetContactFromEmailAddress(request.Email)).ReturnsAsync(contact);
+
+            //Act
+            var result = await sut.Handle(request, new CancellationToken());
+
+            //Assert
+            result.Should().NotBeNull();
+            result.ErrorMessage.Should().NotBeEmpty();
+            result.Success.Should().BeFalse();
+
+            emailApiClient.Verify(x => x.SendEmailWithTemplate(It.IsAny<SendEmailRequest>()), Times.Never);
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Returns_InviteContactToOrganisationResponse(
+            [Frozen] Mock<IContactQueryRepository> contactQueryRepository,
+            [Frozen] Mock<IContactRepository> contactRepository,
+            [Frozen] Mock<IOrganisationQueryRepository> organisationQueryRepository,
+            [Frozen] Mock<IEmailApiClient> emailApiClient,
+            [Frozen] Mock<IApiConfiguration> apiConfiguration,
+            EmailTemplatesConfig emailTemplatesConfig,
+            InviteContactToOrganisationRequest request,
+            InviteContactToOrganisationHandler sut)
+        {
+            //Arrange
+            var contact = new Contact { Id = Guid.NewGuid() };
+            contactQueryRepository.Setup(s => s.GetContactFromEmailAddress(request.Email)).ReturnsAsync((Contact)null);
+            organisationQueryRepository.Setup(s => s.Get(request.OrganisationId)).ReturnsAsync(new Organisation());
+            contactRepository.Setup(x => x.CreateNewContact(It.IsAny<Contact>())).ReturnsAsync(contact);
+            apiConfiguration.Setup(x => x.EmailTemplatesConfig).Returns(emailTemplatesConfig);
+            apiConfiguration.Setup(x => x.ServiceLink).Returns(It.IsAny<string>());
+
+            //Act
+            var result = await sut.Handle(request, new CancellationToken());
+
+            //Assert
+            result.Should().NotBeNull();
+            result.ContactId.Should().Be(contact.Id);
+            result.Success.Should().BeTrue();
+
+            emailApiClient.Verify(x => x.SendEmailWithTemplate(It.IsAny<SendEmailRequest>()), Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Application/Handlers/UserManagement/ApproveContactHandler.cs
+++ b/src/SFA.DAS.AssessorService.Application/Handlers/UserManagement/ApproveContactHandler.cs
@@ -3,8 +3,10 @@ using System.Threading.Tasks;
 using MediatR;
 using SFA.DAS.AssessorService.Api.Types.Models;
 using SFA.DAS.AssessorService.Api.Types.Models.UserManagement;
+using SFA.DAS.AssessorService.Application.Api.Client.Clients;
 using SFA.DAS.AssessorService.Application.Interfaces;
 using SFA.DAS.AssessorService.Domain.Consts;
+using SFA.DAS.AssessorService.Domain.DTOs;
 using SFA.DAS.AssessorService.Settings;
 
 namespace SFA.DAS.AssessorService.Application.Handlers.UserManagement
@@ -13,43 +15,43 @@ namespace SFA.DAS.AssessorService.Application.Handlers.UserManagement
     {
         private readonly IContactRepository _contactRepository;
         private readonly IContactQueryRepository _contactQueryRepository;
-        private readonly IEMailTemplateQueryRepository _eMailTemplateQueryRepository;
-        private readonly IMediator _mediator;
         private readonly IApiConfiguration _config;
         private readonly IOrganisationQueryRepository _organisationQueryRepository;
+        private readonly IEmailApiClient _emailApiClient;
 
-        public ApproveContactHandler(IContactRepository contactRepository, IContactQueryRepository contactQueryRepository,
-            IEMailTemplateQueryRepository eMailTemplateQueryRepository, IMediator mediator, IApiConfiguration config, IOrganisationQueryRepository organisationQueryRepository)
+        public ApproveContactHandler(IContactRepository contactRepository,
+            IContactQueryRepository contactQueryRepository,
+            IApiConfiguration config,
+            IOrganisationQueryRepository organisationQueryRepository,
+            IEmailApiClient emailApiClient)
         {
             _contactRepository = contactRepository;
             _contactQueryRepository = contactQueryRepository;
-            _eMailTemplateQueryRepository = eMailTemplateQueryRepository;
-            _mediator = mediator;
             _config = config;
             _organisationQueryRepository = organisationQueryRepository;
+            _emailApiClient = emailApiClient;
         }
 
         public async Task<Unit> Handle(ApproveContactRequest message, CancellationToken cancellationToken)
         {
-            const string epaoApproveConfirmTemplate = "EPAOUserApproveConfirm";
-
             var contact = await _contactQueryRepository.GetContactById(message.ContactId);
             var organisation = await _organisationQueryRepository.Get(contact.OrganisationId.Value);
 
             await _contactRepository.UpdateContactWithOrganisationData(new UpdateContactWithOrgAndStausRequest(message.ContactId.ToString(),
                 organisation.Id.ToString(), organisation.EndPointAssessorOrganisationId, ContactStatus.Live));
             
-            var emailTemplate = await _eMailTemplateQueryRepository.GetEmailTemplate(epaoApproveConfirmTemplate);
+            // send approve confirmation email to the user with service link.
+            await _emailApiClient.SendEmailWithTemplate(new SendEmailRequest(contact.Email, new EmailTemplateSummary
+            {
+                TemplateId = _config.EmailTemplatesConfig.UserApproveConfirm,
+                TemplateName = nameof(_config.EmailTemplatesConfig.UserApproveConfirm)
+            }, new
+            {
+                name = $"{contact.DisplayName}",
+                organisation = organisation.EndPointAssessorName,
+                link = _config.ServiceLink
+            }));
 
-            await _mediator.Send(new SendEmailRequest(contact.Email,
-                emailTemplate, new
-                {
-                    Contact = $"{contact.DisplayName}",
-                    ServiceName = "Apprenticeship assessment service",
-                    Organisation = organisation.EndPointAssessorName,
-                    LoginLink = _config.ServiceLink,
-                    ServiceTeam = "Apprenticeship assessment services team"
-                }), cancellationToken);
             return Unit.Value;
         }
     }

--- a/src/SFA.DAS.AssessorService.Settings/ApiConfiguration.cs
+++ b/src/SFA.DAS.AssessorService.Settings/ApiConfiguration.cs
@@ -28,5 +28,6 @@ namespace SFA.DAS.AssessorService.Settings
 
         [JsonRequired] public int PipelineCutoff { get; set; }
         [JsonRequired] public string ServiceLink { get; set; }
+        [JsonRequired] public EmailTemplatesConfig EmailTemplatesConfig { get; set; }
     }
 }

--- a/src/SFA.DAS.AssessorService.Settings/EmailTemplatesConfig.cs
+++ b/src/SFA.DAS.AssessorService.Settings/EmailTemplatesConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.AssessorService.Settings
+{
+    public class EmailTemplatesConfig
+    {
+        public string LoginSignupInvite { get; set; }
+    }
+}

--- a/src/SFA.DAS.AssessorService.Settings/EmailTemplatesConfig.cs
+++ b/src/SFA.DAS.AssessorService.Settings/EmailTemplatesConfig.cs
@@ -3,5 +3,6 @@
     public class EmailTemplatesConfig
     {
         public string LoginSignupInvite { get; set; }
+        public string UserApproveConfirm { get; set; }
     }
 }

--- a/src/SFA.DAS.AssessorService.Settings/IApiConfiguration.cs
+++ b/src/SFA.DAS.AssessorService.Settings/IApiConfiguration.cs
@@ -25,5 +25,6 @@
 
         int PipelineCutoff { get; set; }
         string ServiceLink { get; set; }
+        EmailTemplatesConfig EmailTemplatesConfig { get; set; }
     }
 }


### PR DESCRIPTION
Commit Details:
Removed the LoginService from Sending email when a Contact is invited. Instead used the in-service Email Handler for sending Email notification.

Story: https://skillsfundingagency.atlassian.net/browse/FAI-987

`AS AN EPAO user
I WANT to aware of needed a [GOV.uk](http://gov.uk/) One Log in account before I join an existing Assessment service account
SO THAT I will be expecting that as part of that journey`